### PR TITLE
Fix MacOS video renderer disposing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Fixed
 
-- Fix MacOS video renderer disposing. ([#139])
+- Double free when MacOS video renderer is reused for different track. ([#139])
 
 [#139]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/139
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Fixed
 
-- Double free when MacOS video renderer is reused for different track. ([#139])
+- Double free when [macOS] video renderer is reused for different tracks. ([#139])
 
 [#139]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/139
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.9.1] · 2023-??-??
+[0.9.1]: https://github.com/instrumentisto/medea-flutter-webrtc/tree/0.9.1
+
+[Diff](https://github.com/instrumentisto/medea-flutter-webrtc/compare/0.9.0...0.9.1)
+
+### Fixed
+
+- Fix MacOS video renderer disposing. ([#139])
+
+[#139]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/139
+
+
+
+
 ## [0.9.0] · 2023-12-07
 [0.9.0]: https://github.com/instrumentisto/medea-flutter-webrtc/tree/0.9.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 group 'com.instrumentisto.medea_flutter_webrtc'
-version '0.9.0'
+version '0.9.1-dev'
 
 buildscript {
     ext.kotlin_version = '1.7.10'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
   - integration_test (0.0.1):
     - Flutter
   - libyuv-iOS (1.0.2)
-  - medea_flutter_webrtc (0.9.0):
+  - medea_flutter_webrtc (0.9.1-dev):
     - Flutter
     - instrumentisto-libwebrtc-bin (= 118.0.5993.88)
     - libyuv-iOS

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -32,8 +32,8 @@ SPEC CHECKSUMS:
   instrumentisto-libwebrtc-bin: 295e1721ff9a8ccfc030c0de5f095c7d6b3e53ce
   integration_test: 13825b8a9334a850581300559b8839134b124670
   libyuv-iOS: 5a154ccc84ec754029886ecb607512731fe30640
-  medea_flutter_webrtc: 4be3b47ae44588d2e1197e87e0611d3f85d14e60
+  medea_flutter_webrtc: b19006676164ce2b6c917af3ed0397d92de47c0d
 
 PODFILE CHECKSUM: be3ab4e988bb308d23906be69146fcbef66fac55
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.14.2

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - FlutterMacOS (1.0.0)
-  - medea_flutter_webrtc (0.9.0):
+  - medea_flutter_webrtc (0.9.1-dev):
     - FlutterMacOS
 
 DEPENDENCIES:

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -15,8 +15,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  medea_flutter_webrtc: 95bdfc76c203d3cff81b8b38ccfdb6410cf9404b
+  medea_flutter_webrtc: acc418e33d995571e2f3a0a34b54d5c90fb9188d
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.14.2

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -384,7 +384,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.9.1-dev"
   meta:
     dependency: transitive
     description:

--- a/ios/medea_flutter_webrtc.podspec
+++ b/ios/medea_flutter_webrtc.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'medea_flutter_webrtc'
-  s.version          = '0.9.0'
+  s.version          = '0.9.1-dev'
   s.summary          = 'Flutter WebRTC plugin based on Google WebRTC'
   s.description      = <<-DESC
 Flutter WebRTC plugin based on Google WebRTC.

--- a/macos/Classes/VideoRenderer.m
+++ b/macos/Classes/VideoRenderer.m
@@ -154,7 +154,8 @@ void on_frame_caller(void* handler, Frame frame) {
     TextureVideoRenderer* renderer = _renderers[textureId];
 
     int64_t rendererPtr = (int64_t)renderer;
-    // Leaking pointer and it will be freed by Rust calling drop_handler function.
+    // Leaking the pointer which will be freed by Rust calling the
+    // `drop_handler()` function.
     CFBridgingRetain(renderer);
     result(@{
         @"handler_ptr" : [NSNumber numberWithLong:rendererPtr],

--- a/macos/Classes/VideoRenderer.m
+++ b/macos/Classes/VideoRenderer.m
@@ -1,9 +1,9 @@
 #import "VideoRenderer.h"
+#import <Foundation/Foundation.h>
 
 // Drops the provided `TextureVideoRenderer`.
 void drop_handler(void* handler) {
-    TextureVideoRenderer* renderer =
-        (__bridge_transfer TextureVideoRenderer*)handler;
+    CFBridgingRelease(handler);
 }
 
 // Passes the provided `Frame` from Rust side to the specified
@@ -141,7 +141,7 @@ void on_frame_caller(void* handler, Frame frame) {
     NSNumber* textureId = arguments[@"textureId"];
 
     TextureVideoRenderer* renderer = _renderers[textureId];
-    [_registry unregisterTexture:[textureId intValue]];
+    [_registry unregisterTexture:[textureId longValue]];
     [_renderers removeObjectForKey:textureId];
     result(@{});
 }
@@ -155,6 +155,7 @@ void on_frame_caller(void* handler, Frame frame) {
     TextureVideoRenderer* renderer = _renderers[textureId];
 
     int64_t rendererPtr = (int64_t)renderer;
+    CFBridgingRetain(renderer);
     result(@{
         @"handler_ptr" : [NSNumber numberWithLong:rendererPtr],
     });

--- a/macos/Classes/VideoRenderer.m
+++ b/macos/Classes/VideoRenderer.m
@@ -154,6 +154,7 @@ void on_frame_caller(void* handler, Frame frame) {
     TextureVideoRenderer* renderer = _renderers[textureId];
 
     int64_t rendererPtr = (int64_t)renderer;
+    // Leaking pointer and it will be freed by Rust calling drop_handler function.
     CFBridgingRetain(renderer);
     result(@{
         @"handler_ptr" : [NSNumber numberWithLong:rendererPtr],

--- a/macos/Classes/VideoRenderer.m
+++ b/macos/Classes/VideoRenderer.m
@@ -1,5 +1,4 @@
 #import "VideoRenderer.h"
-#import <Foundation/Foundation.h>
 
 // Drops the provided `TextureVideoRenderer`.
 void drop_handler(void* handler) {

--- a/macos/medea_flutter_webrtc.podspec
+++ b/macos/medea_flutter_webrtc.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'medea_flutter_webrtc'
-  s.version          = '0.9.0'
+  s.version          = '0.9.1-dev'
   s.summary          = 'Flutter WebRTC plugin based on Google WebRTC'
   s.description      = <<-DESC
 Flutter WebRTC plugin based on Google WebRTC.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: medea_flutter_webrtc
 description: >
   Flutter WebRTC plugin for Android/iOS/macOS/Linux/Windows/Web, based on
   GoogleWebRTC, designed for and used in Medea Jason WebRTC client.
-version: 0.9.0
+version: 0.9.1-dev
 homepage: https://github.com/instrumentisto/medea-flutter-webrtc
 
 environment:


### PR DESCRIPTION
## Synopsis

At this moment we have bug which is easily reproducible in our `getUserMedia` example.

### Steps for reproduce:

1. Start `GetUserMedia` demo
2. Change video camera to any camera (it can be the same camera)
3. Change video camera second time
=> segfault




## Solution

Fix memory management issues in MacOS's implementation of `VideoRenderer.m`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
