### PR TITLE
Fix error propagation on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ All user visible changes to this project will be documented in this file. This p
 ### Fixed
 
 - Double free when [macOS] video renderer is reused for different tracks. ([#139])
+- Swift exceptions not being propagated to Dart side on [iOS]. ([#142])
+- Segfault when switching to external camera on [macOS]. ([#142])
 
 [#139]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/139
+[#142]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/142
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All user visible changes to this project will be documented in this file. This p
 ### Fixed
 
 - Double free when [macOS] video renderer is reused for different tracks. ([#139])
-- Swift exceptions not being propagated to Dart side on [iOS]. ([#142])
+- [Swift] exceptions not being propagated to [Dart] side on [iOS]. ([#142])
 - Segfault when switching to external camera on [macOS]. ([#142])
 
 [#139]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/139
@@ -188,6 +188,7 @@ See [changelog in upstream repository](https://github.com/flutter-webrtc/flutter
 
 
 [Android]: https://www.android.com
+[Dart]: https://dart.dev
 [Flutter]: https://www.flutter.dev
 [iOS]: https://www.apple.com/ios
 [libwebrtc]: https://github.com/instrumentisto/libwebrtc-bin
@@ -195,4 +196,5 @@ See [changelog in upstream repository](https://github.com/flutter-webrtc/flutter
 [macOS]: https://www.apple.com/macos
 [OpenAL]: https://github.com/kcat/openal-soft
 [Semantic Versioning 2.0.0]: https://semver.org
+[Swift]: https://developer.apple.com/swift
 [Windows]: https://www.microsoft.com/windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7129e341034ecb940c9072817cd9007974ea696844fc4dd582dc1653a7fbe2e8"
+checksum = "e9fc0c733f71e58dedf4f034cd2a266f80b94cc9ed512729e1798651b68c2cba"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a24f3f5f8eed71936f21e570436f024f5c2e25628f7496aa7ccd03b90109d5"
+checksum = "51bc81d2664db24cf1d35405f66e18a85cffd4d49ab930c71a5c6342a410f38c"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -211,24 +211,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06fdd177fc61050d63f67f5bd6351fac6ab5526694ea8e359cd9cd3b75857f44"
+checksum = "8511afbe34ea242697784da5cb2c5d4a0afb224ca8b136bdf93bfe180cbe5884"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587663dd5fb3d10932c8aecfe7c844db1bcf0aee93eeab08fac13dc1212c2e7f"
+checksum = "5c6888cd161769d65134846d4d4981d5a6654307cc46ec83fb917e530aea5f84"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -309,14 +309,14 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "filetime"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.3.5",
- "windows-sys 0.48.0",
+ "redox_syscall",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
  "http",
@@ -520,9 +520,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -535,7 +535,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -583,9 +583,9 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
@@ -604,9 +604,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "libpulse-binding"
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
@@ -828,15 +828,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -855,7 +855,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -866,9 +866,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
 dependencies = [
  "cc",
  "libc",
@@ -894,7 +894,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -943,15 +943,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -961,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.22"
+version = "0.11.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "base64",
  "bytes",
@@ -1014,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.26"
+version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9470c4bf8246c8daf25f9598dca807fb6510347b1e1cfa55749113850c79d88a"
+checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -1027,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "same-file"
@@ -1107,7 +1098,7 @@ checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1161,16 +1152,6 @@ checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "socket2"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
@@ -1192,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1241,7 +1222,7 @@ checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall 0.4.1",
+ "redox_syscall",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -1281,9 +1262,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1291,7 +1272,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2",
  "windows-sys 0.48.0",
 ]
 
@@ -1346,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -1358,9 +1339,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-ident"
@@ -1452,7 +1433,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "wasm-bindgen-shared",
 ]
 
@@ -1486,7 +1467,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1567,7 +1548,7 @@ checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1578,7 +1559,7 @@ checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.41",
 ]
 
 [[package]]
@@ -1725,11 +1706,13 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.0.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+checksum = "a7dae5072fe1f8db8f8d29059189ac175196e410e40ba42d5d4684ae2f750995"
 dependencies = [
  "libc",
+ "linux-raw-sys",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/libwebrtc-sys/src/cpp/device_info_mac.mm
+++ b/crates/libwebrtc-sys/src/cpp/device_info_mac.mm
@@ -14,11 +14,16 @@ int32_t DeviceInfoMac::Init() {
 DeviceInfoMac::~DeviceInfoMac() {}
 
 uint32_t DeviceInfoMac::NumberOfDevices() {
-  AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
-      discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternalUnknown]
-      mediaType:AVMediaTypeVideo
-      position:AVCaptureDevicePositionUnspecified];
-  NSArray<AVCaptureDevice *> *devices = discoverySession.devices;
+  AVCaptureDeviceDiscoverySession* discoverySession =
+      [AVCaptureDeviceDiscoverySession
+          discoverySessionWithDeviceTypes:@[
+            AVCaptureDeviceTypeBuiltInWideAngleCamera,
+            AVCaptureDeviceTypeExternalUnknown
+          ]
+          mediaType:AVMediaTypeVideo
+          position:AVCaptureDevicePositionUnspecified];
+
+  NSArray<AVCaptureDevice*>* devices = discoverySession.devices;
 
   return [devices count];
 }
@@ -35,12 +40,16 @@ int32_t DeviceInfoMac::GetDeviceName(uint32_t deviceNumber,
                                      uint32_t deviceUniqueIdUTF8Length,
                                      char* /*productUniqueIdUTF8*/,
                                      uint32_t /*productUniqueIdUTF8Length*/) {
-  AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
-      discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternalUnknown]
-      mediaType:AVMediaTypeVideo
-      position:AVCaptureDevicePositionUnspecified];
+  AVCaptureDeviceDiscoverySession* discoverySession =
+      [AVCaptureDeviceDiscoverySession
+          discoverySessionWithDeviceTypes:@[
+            AVCaptureDeviceTypeBuiltInWideAngleCamera,
+            AVCaptureDeviceTypeExternalUnknown
+          ]
+          mediaType:AVMediaTypeVideo
+          position:AVCaptureDevicePositionUnspecified];
 
-  NSArray<AVCaptureDevice *> *devices = discoverySession.devices;
+  NSArray<AVCaptureDevice*>* devices = discoverySession.devices;
   AVCaptureDevice* device = devices[deviceNumber];
   deviceNameLength = [device.localizedName length];
   memset(deviceNameUTF8, 0, deviceNameLength);

--- a/crates/libwebrtc-sys/src/cpp/device_info_mac.mm
+++ b/crates/libwebrtc-sys/src/cpp/device_info_mac.mm
@@ -14,8 +14,12 @@ int32_t DeviceInfoMac::Init() {
 DeviceInfoMac::~DeviceInfoMac() {}
 
 uint32_t DeviceInfoMac::NumberOfDevices() {
-  NSArray<AVCaptureDevice*>* devices =
-      [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+  AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
+      discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternalUnknown]
+      mediaType:AVMediaTypeVideo
+      position:AVCaptureDevicePositionUnspecified];
+  NSArray<AVCaptureDevice *> *devices = discoverySession.devices;
+
   return [devices count];
 }
 
@@ -31,8 +35,12 @@ int32_t DeviceInfoMac::GetDeviceName(uint32_t deviceNumber,
                                      uint32_t deviceUniqueIdUTF8Length,
                                      char* /*productUniqueIdUTF8*/,
                                      uint32_t /*productUniqueIdUTF8Length*/) {
-  NSArray<AVCaptureDevice*>* devices =
-      [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+  AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
+      discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternalUnknown]
+      mediaType:AVMediaTypeVideo
+      position:AVCaptureDevicePositionUnspecified];
+
+  NSArray<AVCaptureDevice *> *devices = discoverySession.devices;
   AVCaptureDevice* device = devices[deviceNumber];
   deviceNameLength = [device.localizedName length];
   memset(deviceNameUTF8, 0, deviceNameLength);

--- a/crates/libwebrtc-sys/src/cpp/mac_capturer.mm
+++ b/crates/libwebrtc-sys/src/cpp/mac_capturer.mm
@@ -76,8 +76,14 @@ rtc::scoped_refptr<MacCapturer> MacCapturer::Create(size_t width,
                                                     size_t height,
                                                     size_t target_fps,
                                                     uint32_t capture_device_index) {
+  AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
+      discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternalUnknown]
+      mediaType:AVMediaTypeVideo
+      position:AVCaptureDevicePositionUnspecified];
+
+  NSArray<AVCaptureDevice *> *devices = discoverySession.devices;
   AVCaptureDevice* device =
-      [[RTCCameraVideoCapturer captureDevices] objectAtIndex:capture_device_index];
+      [devices objectAtIndex:capture_device_index];
   if (!device) {
     RTC_LOG(LS_ERROR) << "Failed to create MacCapture";
     return nullptr;

--- a/crates/libwebrtc-sys/src/cpp/mac_capturer.mm
+++ b/crates/libwebrtc-sys/src/cpp/mac_capturer.mm
@@ -76,14 +76,17 @@ rtc::scoped_refptr<MacCapturer> MacCapturer::Create(size_t width,
                                                     size_t height,
                                                     size_t target_fps,
                                                     uint32_t capture_device_index) {
-  AVCaptureDeviceDiscoverySession *discoverySession = [AVCaptureDeviceDiscoverySession
-      discoverySessionWithDeviceTypes:@[AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternalUnknown]
-      mediaType:AVMediaTypeVideo
-      position:AVCaptureDevicePositionUnspecified];
+  AVCaptureDeviceDiscoverySession* discoverySession =
+      [AVCaptureDeviceDiscoverySession
+          discoverySessionWithDeviceTypes:@[
+            AVCaptureDeviceTypeBuiltInWideAngleCamera,
+            AVCaptureDeviceTypeExternalUnknown
+          ]
+          mediaType:AVMediaTypeVideo
+          position:AVCaptureDevicePositionUnspecified];
 
-  NSArray<AVCaptureDevice *> *devices = discoverySession.devices;
-  AVCaptureDevice* device =
-      [devices objectAtIndex:capture_device_index];
+  NSArray<AVCaptureDevice*>* devices = discoverySession.devices;
+  AVCaptureDevice* device = [devices objectAtIndex:capture_device_index];
   if (!device) {
     RTC_LOG(LS_ERROR) << "Failed to create MacCapture";
     return nullptr;

--- a/ios/Classes/controller/MediaStreamTrackController.swift
+++ b/ios/Classes/controller/MediaStreamTrackController.swift
@@ -79,7 +79,7 @@ class MediaStreamTrackController {
           .asFlutterResult()
         )
       } catch {
-        result(error)
+        result(getFlutterError(error))
       }
     case "dispose":
       self.isDisposed = true

--- a/ios/Classes/controller/PeerConnectionController.swift
+++ b/ios/Classes/controller/PeerConnectionController.swift
@@ -76,7 +76,7 @@ class PeerConnectionController {
           let sdp = try await self.peer.createOffer()
           self.sendResultFromTask(result, sdp.asFlutterResult())
         } catch {
-          self.sendResultFromTask(result, error)
+          self.sendResultFromTask(result, getFlutterError(error))
         }
       }
     case "createAnswer":
@@ -101,7 +101,7 @@ class PeerConnectionController {
           try await self.peer.setLocalDescription(description: desc)
           self.sendResultFromTask(result, nil)
         } catch {
-          self.sendResultFromTask(result, error)
+          self.sendResultFromTask(result, getFlutterError(error))
         }
       }
     case "setRemoteDescription":
@@ -118,7 +118,7 @@ class PeerConnectionController {
           )
           self.sendResultFromTask(result, nil)
         } catch {
-          self.sendResultFromTask(result, error)
+          self.sendResultFromTask(result, getFlutterError(error))
         }
       }
     case "addIceCandidate":
@@ -136,7 +136,7 @@ class PeerConnectionController {
           )
           self.sendResultFromTask(result, nil)
         } catch {
-          self.sendResultFromTask(result, error)
+          self.sendResultFromTask(result, getFlutterError(error))
         }
       }
     case "addTransceiver":

--- a/ios/Classes/utils/FlutterError.swift
+++ b/ios/Classes/utils/FlutterError.swift
@@ -1,3 +1,4 @@
+/// Converts provided Swift `Error` to `FlutterError`.
 func getFlutterError(_ error: Error) -> FlutterError {
     let e = error as NSError
     return FlutterError(code: "Error: \(e.code)", message: e.domain, details: error.localizedDescription)

--- a/ios/Classes/utils/FlutterError.swift
+++ b/ios/Classes/utils/FlutterError.swift
@@ -1,4 +1,4 @@
-/// Converts provided Swift `Error` to `FlutterError`.
+/// Converts the provided Swift `Error` into a `FlutterError`.
 func getFlutterError(_ error: Error) -> FlutterError {
   let e = error as NSError
   return FlutterError(

--- a/ios/Classes/utils/FlutterError.swift
+++ b/ios/Classes/utils/FlutterError.swift
@@ -1,5 +1,9 @@
 /// Converts provided Swift `Error` to `FlutterError`.
 func getFlutterError(_ error: Error) -> FlutterError {
-    let e = error as NSError
-    return FlutterError(code: "Error: \(e.code)", message: e.domain, details: error.localizedDescription)
+  let e = error as NSError
+  return FlutterError(
+    code: "Error: \(e.code)",
+    message: e.domain,
+    details: error.localizedDescription
+  )
 }

--- a/ios/Classes/utils/FlutterError.swift
+++ b/ios/Classes/utils/FlutterError.swift
@@ -1,0 +1,4 @@
+func getFlutterError(_ error: Error) -> FlutterError {
+    let e = error as NSError
+    return FlutterError(code: "Error: \(e.code)", message: e.domain, details: error.localizedDescription)
+}


### PR DESCRIPTION
## Synopsis

Currently, we have incorrect implementation of Swift's error in our iOS implementation. We trying to pass just `Error` types to `result` function, but Flutter requires it to be with specific interface implementation, so it will not work. We need to fix it.




## Solution

Convert Swift's `Error`s to `FlutterError` by getting things like description and code from `Error` and constructing `FlutterError` with it.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
