### PR TITLE
Fix output audio device related bugs on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,14 @@ All user visible changes to this project will be documented in this file. This p
 - Double free when [macOS] video renderer is reused for different tracks. ([#139])
 - [Swift] exceptions not being propagated to [Dart] side on [iOS]. ([#142])
 - Segfault when switching to external camera on [macOS]. ([#142])
+- Unexpected audio category on `setOutputAudioId` call on [iOS]. ([#146])
+- Race condition bug on `setOutputAudioId` call on [Android]. ([#146])
 
 [#139]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/139
 [#142]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/142
 [#144]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/144
 [#145]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/145
+[#146]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/146
 
 
 

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
@@ -94,13 +94,13 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
   /** [CompletableDeferred] being resolved once Bluetooth SCO request is completed. */
   private var bluetoothScoDeferred: CompletableDeferred<Unit>? = null
 
-  /** [Mutex] that ensures only one call to [setOutputAudioId] can be executed at a time. */
+  /** [Mutex] ensuring only one call to [setOutputAudioId] can be executed at the time. */
   private var setOutputAudioMutex: Mutex = Mutex()
 
   /** [CompletableDeferred] being resolved once Bluetooth SCO is completely stopped. */
   private var stopBluetoothScoDeferred: CompletableDeferred<Unit>? = null
 
-  /** Indicates whether bluetooth SCO is connected. */
+  /** Indicator whether bluetooth SCO is connected. */
   private var scoAudioStateConnected: Boolean = false
 
   companion object {

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
@@ -263,22 +263,19 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
           audioManager.isSpeakerphoneOn = true
         }
         BLUETOOTH_HEADSET_DEVICE_ID -> {
-          if (audioManager.isBluetoothScoOn) {
-            return;
-          }
           val deviceIdBefore = selectedAudioOutputId
           selectedAudioOutputId = deviceId
           if (isBluetoothHeadsetConnected) {
-            // if (bluetoothScoDeferred == null) {
+            if (bluetoothScoDeferred == null) {
               isBluetoothScoFailed = false
               Log.d(
                   "FlutterWebRtcDebug",
                   "Bluetooth headset was selected. Trying to start Bluetooth SCO...")
               bluetoothScoDeferred = CompletableDeferred()
               audioManager.startBluetoothSco()
-            // }
+            }
             try {
-              withTimeout(5000L) { bluetoothScoDeferred?.await() }
+              bluetoothScoDeferred?.await()
             } catch (e: Exception) {
               Log.e("setOutputAudioId", "3 BLUETOOTH_HEADSET_DEVICE_ID EEE ${e}")
               selectedAudioOutputId = deviceIdBefore

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
@@ -21,10 +21,10 @@ import com.instrumentisto.medea_flutter_webrtc.proxy.VideoMediaTrackSource
 import com.instrumentisto.medea_flutter_webrtc.utils.EglUtils
 import java.util.*
 import kotlinx.coroutines.CompletableDeferred
-import org.webrtc.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
+import org.webrtc.*
 
 /**
  * Default device video width.
@@ -94,9 +94,7 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
   /** [CompletableDeferred] being resolved once Bluetooth SCO request is completed. */
   private var bluetoothScoDeferred: CompletableDeferred<Unit>? = null
 
-  /**
-   * [Mutex] that ensures only one call to [setOutputAudioId] can be executed at a time.
-   */
+  /** [Mutex] that ensures only one call to [setOutputAudioId] can be executed at a time. */
   private var outputMutex: Mutex = Mutex()
 
   companion object {
@@ -257,9 +255,7 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
               audioManager.startBluetoothSco()
             }
             try {
-              withTimeout(50000L) {
-                bluetoothScoDeferred?.await()
-              }
+              withTimeout(50000L) { bluetoothScoDeferred?.await() }
             } catch (e: Exception) {
               selectedAudioOutputId = deviceIdBefore
               audioManager.stopBluetoothSco()

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
@@ -22,6 +22,9 @@ import com.instrumentisto.medea_flutter_webrtc.utils.EglUtils
 import java.util.*
 import kotlinx.coroutines.CompletableDeferred
 import org.webrtc.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
 
 /**
  * Default device video width.
@@ -90,6 +93,11 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
 
   /** [CompletableDeferred] being resolved once Bluetooth SCO request is completed. */
   private var bluetoothScoDeferred: CompletableDeferred<Unit>? = null
+
+  /**
+   * [Mutex] that ensures only one call to [setOutputAudioId] can be executed at a time.
+   */
+  private var outputMutex: Mutex = Mutex()
 
   companion object {
     /** Observer of [MediaDevices] events. */
@@ -225,42 +233,46 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
    * @param deviceId Identifier for the output audio device to be selected.
    */
   suspend fun setOutputAudioId(deviceId: String) {
-    val audioManager = state.getAudioManager()
-    when (deviceId) {
-      EAR_SPEAKER_DEVICE_ID -> {
-        cancelBluetoothSco()
-        audioManager.isSpeakerphoneOn = false
-      }
-      SPEAKERPHONE_DEVICE_ID -> {
-        cancelBluetoothSco()
-        audioManager.isSpeakerphoneOn = true
-      }
-      BLUETOOTH_HEADSET_DEVICE_ID -> {
-        val deviceIdBefore = selectedAudioOutputId
-        selectedAudioOutputId = deviceId
-        if (isBluetoothHeadsetConnected) {
-          if (bluetoothScoDeferred == null) {
-            isBluetoothScoFailed = false
-            Log.d(
-                "FlutterWebRtcDebug",
-                "Bluetooth headset was selected. Trying to start Bluetooth SCO...")
-            bluetoothScoDeferred = CompletableDeferred()
-            audioManager.startBluetoothSco()
+    outputMutex.withLock {
+      val audioManager = state.getAudioManager()
+      when (deviceId) {
+        EAR_SPEAKER_DEVICE_ID -> {
+          cancelBluetoothSco()
+          audioManager.isSpeakerphoneOn = false
+        }
+        SPEAKERPHONE_DEVICE_ID -> {
+          cancelBluetoothSco()
+          audioManager.isSpeakerphoneOn = true
+        }
+        BLUETOOTH_HEADSET_DEVICE_ID -> {
+          val deviceIdBefore = selectedAudioOutputId
+          selectedAudioOutputId = deviceId
+          if (isBluetoothHeadsetConnected) {
+            if (bluetoothScoDeferred == null) {
+              isBluetoothScoFailed = false
+              Log.d(
+                  "FlutterWebRtcDebug",
+                  "Bluetooth headset was selected. Trying to start Bluetooth SCO...")
+              bluetoothScoDeferred = CompletableDeferred()
+              audioManager.startBluetoothSco()
+            }
+            try {
+              withTimeout(50000L) {
+                bluetoothScoDeferred?.await()
+              }
+            } catch (e: Exception) {
+              selectedAudioOutputId = deviceIdBefore
+              audioManager.stopBluetoothSco()
+              isBluetoothScoFailed = true
+              throw e
+            }
+          } else {
+            throw IllegalArgumentException("Unknown output device: $deviceId")
           }
-          try {
-            bluetoothScoDeferred?.await()
-          } catch (e: Exception) {
-            selectedAudioOutputId = deviceIdBefore
-            audioManager.stopBluetoothSco()
-            isBluetoothScoFailed = true
-            throw e
-          }
-        } else {
+        }
+        else -> {
           throw IllegalArgumentException("Unknown output device: $deviceId")
         }
-      }
-      else -> {
-        throw IllegalArgumentException("Unknown output device: $deviceId")
       }
     }
   }

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
@@ -95,7 +95,7 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
   private var bluetoothScoDeferred: CompletableDeferred<Unit>? = null
 
   /** [Mutex] that ensures only one call to [setOutputAudioId] can be executed at a time. */
-  private var outputMutex: Mutex = Mutex()
+  private var setOutputAudioMutex: Mutex = Mutex()
 
   /** [CompletableDeferred] being resolved once Bluetooth SCO is completely stopped. */
   private var stopBluetoothScoDeferred: CompletableDeferred<Unit>? = null
@@ -240,7 +240,7 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
    * @param deviceId Identifier for the output audio device to be selected.
    */
   suspend fun setOutputAudioId(deviceId: String) {
-    outputMutex.withLock {
+    setOutputAudioMutex.withLock {
       val audioManager = state.getAudioManager()
       when (deviceId) {
         EAR_SPEAKER_DEVICE_ID -> {

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MediaDevices.kt
@@ -245,7 +245,7 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
         GetUserMediaException(
             "Bluetooth headset connection request was cancelled", GetUserMediaException.Kind.Audio))
     bluetoothScoDeferred = null
-   }
+  }
 
   /**
    * Switches the current output audio device to the device with the provided identifier.
@@ -293,7 +293,7 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
               throw e
             }
           } else {
-              Log.e("setOutputAudioId", "4 BLUETOOTH_HEADSET_DEVICE_ID EEE ${deviceId}")
+            Log.e("setOutputAudioId", "4 BLUETOOTH_HEADSET_DEVICE_ID EEE ${deviceId}")
             throw IllegalArgumentException("Unknown output device: $deviceId")
           }
         }
@@ -483,30 +483,30 @@ class MediaDevices(val state: State, private val permissions: Permissions) : Bro
         val state =
             intent.getIntExtra(
                 AudioManager.EXTRA_SCO_AUDIO_STATE, AudioManager.SCO_AUDIO_STATE_DISCONNECTED)
-          when (state) {
-            AudioManager.SCO_AUDIO_STATE_CONNECTED -> {
-              Log.d("FlutterWebRtcDebug", "SCO connected")
-              scoAudioStateConnected = true
-              isBluetoothScoFailed = false
-              bluetoothScoDeferred?.complete(Unit)
-              bluetoothScoDeferred = null
-              audioManager.isBluetoothScoOn = true
-              audioManager.isSpeakerphoneOn = false
-            }
-            AudioManager.SCO_AUDIO_STATE_DISCONNECTED -> {
-              Log.d("FlutterWebRtcDebug", "SCO disconnected")
-              scoAudioStateConnected = false
-              isBluetoothScoFailed = true
-              stopBluetoothScoDeferred?.complete(Unit)
-              stopBluetoothScoDeferred = null
-              bluetoothScoDeferred?.completeExceptionally(
-                  GetUserMediaException(
-                      "Bluetooth headset is unavailable at this moment",
-                      GetUserMediaException.Kind.Audio))
-              bluetoothScoDeferred = null
-              Handler(Looper.getMainLooper()).post { eventBroadcaster().onDeviceChange() }
-            }
+        when (state) {
+          AudioManager.SCO_AUDIO_STATE_CONNECTED -> {
+            Log.d("FlutterWebRtcDebug", "SCO connected")
+            scoAudioStateConnected = true
+            isBluetoothScoFailed = false
+            bluetoothScoDeferred?.complete(Unit)
+            bluetoothScoDeferred = null
+            audioManager.isBluetoothScoOn = true
+            audioManager.isSpeakerphoneOn = false
           }
+          AudioManager.SCO_AUDIO_STATE_DISCONNECTED -> {
+            Log.d("FlutterWebRtcDebug", "SCO disconnected")
+            scoAudioStateConnected = false
+            isBluetoothScoFailed = true
+            stopBluetoothScoDeferred?.complete(Unit)
+            stopBluetoothScoDeferred = null
+            bluetoothScoDeferred?.completeExceptionally(
+                GetUserMediaException(
+                    "Bluetooth headset is unavailable at this moment",
+                    GetUserMediaException.Kind.Audio))
+            bluetoothScoDeferred = null
+            Handler(Looper.getMainLooper()).post { eventBroadcaster().onDeviceChange() }
+          }
+        }
       }
     }
   }

--- a/ios/Classes/MediaDevices.swift
+++ b/ios/Classes/MediaDevices.swift
@@ -46,6 +46,10 @@ class MediaDevices {
   /// Switches current audio output device to a device with the provided ID.
   func setOutputAudioId(id: String) {
     let session = AVAudioSession.sharedInstance()
+    try! AVAudioSession.sharedInstance().setCategory(
+      AVAudioSession.Category.playAndRecord,
+      options: AVAudioSession.CategoryOptions.allowBluetooth
+    )
     if id == "speaker" {
       self.setBuiltInMicAsInput()
       try! AVAudioSession.sharedInstance().overrideOutputAudioPort(.speaker)


### PR DESCRIPTION
## Synopsis

This PR fixes bugs related to the output audio devices selecting bugs on iOS and Android platforms.




## Solution

### iOS

Add category switching to `playAndRecord` on every `setOutputAudioId` call.

It's needed because some other Flutter plugin used by the frontend can change this category and we can't control it. So for guarantees that all our switches will be performed in a required audio category we should perform category switching before doing anything with `AudioSession`.

### Android

Sometimes we can encounter race conditions while calling `setOutputAudioId` simultaneously without awaiting for the previous call. So to fix this, we just adding `Mutex` and will wait until previous switch is performed.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
