### PR TITLE
Fix `AudioSource` reuse after `PeerConnection` close

### DIFF
--- a/crates/libwebrtc-sys/include/adm.h
+++ b/crates/libwebrtc-sys/include/adm.h
@@ -76,7 +76,7 @@ class OpenALAudioDeviceModule : public ExtendedADM {
   static rtc::scoped_refptr<OpenALAudioDeviceModule> Create(
       AudioLayer audio_layer,
       webrtc::TaskQueueFactory* task_queue_factory,
-      webrtc::AudioProcessing* audio_processing);
+      const std::unique_ptr<rtc::scoped_refptr<webrtc::AudioProcessing>>& audio_processing);
 
   // Main initialization and termination.
   int32_t Init() override;

--- a/crates/libwebrtc-sys/include/bridge.h
+++ b/crates/libwebrtc-sys/include/bridge.h
@@ -128,7 +128,7 @@ std::unique_ptr<AudioDeviceModule> create_audio_device_module(
     Thread& worker_thread,
     AudioLayer audio_layer,
     TaskQueueFactory& task_queue_factory,
-    const AudioProcessing& ap);
+    const std::unique_ptr<AudioProcessing>& ap);
 
 // Initializes the native audio parts required for each platform.
 int32_t init_audio_device_module(const AudioDeviceModule& audio_device_module);

--- a/crates/libwebrtc-sys/src/bridge.rs
+++ b/crates/libwebrtc-sys/src/bridge.rs
@@ -1488,7 +1488,7 @@ pub(crate) mod webrtc {
             worker_thread: Pin<&mut Thread>,
             audio_layer: AudioLayer,
             task_queue_factory: Pin<&mut TaskQueueFactory>,
-            ap: &AudioProcessing,
+            ap: &UniquePtr<AudioProcessing>,
         ) -> UniquePtr<AudioDeviceModule>;
 
         /// Initializes the given [`AudioDeviceModule`].

--- a/crates/libwebrtc-sys/src/cpp/adm.cc
+++ b/crates/libwebrtc-sys/src/cpp/adm.cc
@@ -165,10 +165,14 @@ int32_t OpenALAudioDeviceModule::ActiveAudioLayer(
 rtc::scoped_refptr<OpenALAudioDeviceModule> OpenALAudioDeviceModule::Create(
     AudioLayer audio_layer,
     webrtc::TaskQueueFactory* task_queue_factory,
-    webrtc::AudioProcessing* audio_processing) {
+    const std::unique_ptr<rtc::scoped_refptr<webrtc::AudioProcessing>>& audio_processing) {
   auto adm = rtc::make_ref_counted<OpenALAudioDeviceModule>();
 
-  adm->audio_processing_ = audio_processing;
+  if (!audio_processing.get()) {
+    adm->audio_processing_ = nullptr;
+  } else {
+    adm->audio_processing_ = audio_processing.get()->get();
+  }
   adm->audio_device_buffer_ =
       std::make_unique<webrtc::AudioDeviceBuffer>(task_queue_factory);
 

--- a/crates/libwebrtc-sys/src/cpp/adm.cc
+++ b/crates/libwebrtc-sys/src/cpp/adm.cc
@@ -843,6 +843,12 @@ bool OpenALAudioDeviceModule::RecordingIsInitialized() const {
 }
 
 int32_t OpenALAudioDeviceModule::StartRecording() {
+  for (const auto& [_, recorder] : _recorders) {
+    recorder->StartCapture();
+  }
+  ensureThreadStarted();
+  startCaptureOnThread();
+
   return 0;
 }
 

--- a/crates/libwebrtc-sys/src/cpp/bridge.cc
+++ b/crates/libwebrtc-sys/src/cpp/bridge.cc
@@ -115,13 +115,13 @@ std::unique_ptr<AudioDeviceModule> create_audio_device_module(
     Thread& worker_thread,
     AudioLayer audio_layer,
     TaskQueueFactory& task_queue_factory,
-    const AudioProcessing& ap) {
+    const std::unique_ptr<AudioProcessing>& ap) {
   AudioDeviceModule adm = worker_thread.BlockingCall([audio_layer,
                                                       &task_queue_factory,
                                                       &ap] {
     return ::OpenALAudioDeviceModule::Create(audio_layer,
                                              &task_queue_factory,
-                                             ap.get());
+                                             ap);
   });
 
   if (adm == nullptr) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -350,26 +350,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -413,10 +413,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -594,10 +594,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   timing:
     dependency: transitive
     description:
@@ -642,10 +642,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:
@@ -688,4 +688,4 @@ packages:
     version: "3.1.2"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.10.0"
+  flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
## Synopsis

This PR fixes bug in scenarios when user of `flutter_webrtc` library closes `PeerConnection`s, but not closes `MediaStreamTrack`s. In this case `AudioSource` will be reused on next `PeerConnection` open, but because of caching mechanisms in `native` crate. Meanwhile `audio_device_recorder` will do nothing, because `_recording_thread` was stopped on `PeerConnection` close, but not started again when new `PeerConnection` was opened, because currently we start `_recordingThread` only when creating new `AudioSource`.




## Solution

Start `_recording_thread` and `audio_device_recorder` in `OpenALAudioDeviceModule::StartRecording`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
