### PR TITLE
Fix RTC stats on desktop platforms

### DIFF
--- a/crates/libwebrtc-sys/src/cpp/stats.cc
+++ b/crates/libwebrtc-sys/src/cpp/stats.cc
@@ -101,21 +101,6 @@ RTCOutboundRTPStreamStatsWrap cast_to_rtc_outbound_rtp_stream_stats(
       track_id->set_value(rust::String(*cast->remote_id));
     }
 
-    auto frame_width = init_option_u32();
-    if (cast->frame_width.has_value()) {
-      frame_width->set_value(*cast->frame_width);
-    }
-
-    auto frame_height = init_option_u32();
-    if (cast->frame_width.has_value()) {
-      frame_width->set_value(*cast->frame_width);
-    }
-
-    auto frames_per_second = init_option_f64();
-    if (cast->frames_per_second.has_value()) {
-      frames_per_second->set_value(*cast->frames_per_second);
-    }
-
     auto bytes_sent = init_option_u64();
     if (cast->bytes_sent.has_value()) {
       bytes_sent->set_value(*cast->bytes_sent);
@@ -131,7 +116,27 @@ RTCOutboundRTPStreamStatsWrap cast_to_rtc_outbound_rtp_stream_stats(
       media_source_id->set_value(rust::String(*cast->media_source_id));
     }
 
-    MediaKind kind = MediaKind::Video;
+    auto frame_width = init_option_u32();
+    auto frame_height = init_option_u32();
+    auto frames_per_second = init_option_f64();
+    MediaKind kind;
+    if (*cast->kind == "audio") {
+      kind = MediaKind::Audio;
+    } else {
+      kind = MediaKind::Video;
+
+      if (cast->frame_width.has_value()) {
+        frame_width->set_value(*cast->frame_width);
+      }
+
+      if (cast->frame_height.has_value()) {
+        frame_height->set_value(*cast->frame_height);
+      }
+
+      if (cast->frames_per_second.has_value()) {
+        frames_per_second->set_value(*cast->frames_per_second);
+      }
+    }
 
     return RTCOutboundRTPStreamStatsWrap{
         std::move(track_id),          kind,
@@ -246,22 +251,22 @@ RTCInboundRTPStreamStatsWrap cast_to_rtc_inbound_rtp_stream_stats(
       if (cast->frames_received.has_value()) {
         frames_received->set_value(*cast->frames_received);
       }
+    }
 
-      if (cast->bytes_received.has_value()) {
-        bytes_received->set_value(*cast->bytes_received);
-      }
+    if (cast->bytes_received.has_value()) {
+      bytes_received->set_value(*cast->bytes_received);
+    }
 
-      if (cast->packets_received.has_value()) {
-        packets_received->set_value(*cast->packets_received);
-      }
+    if (cast->packets_received.has_value()) {
+      packets_received->set_value(*cast->packets_received);
+    }
 
-      if (cast->total_decode_time.has_value()) {
-        total_decode_time->set_value(*cast->total_decode_time);
-      }
-      if (cast->jitter_buffer_emitted_count.has_value()) {
-        jitter_buffer_emitted_count->set_value(
-            *cast->jitter_buffer_emitted_count);
-      }
+    if (cast->total_decode_time.has_value()) {
+      total_decode_time->set_value(*cast->total_decode_time);
+    }
+    if (cast->jitter_buffer_emitted_count.has_value()) {
+      jitter_buffer_emitted_count->set_value(
+          *cast->jitter_buffer_emitted_count);
     }
 
     return RTCInboundRTPStreamStatsWrap{

--- a/lib/src/model/stats.dart
+++ b/lib/src/model/stats.dart
@@ -693,12 +693,12 @@ class RtcOutboundRtpStreamStats extends RtcStatsType {
       ffi.RtcStatsType_RtcOutboundRtpStreamStats stats) {
     RtcOutboundRtpStreamStatsMediaType? mediaType;
     var kind = stats.mediaType.runtimeType.toString().substring(2);
-    if (kind == 'RtcOutboundRtpStreamStatsKind_Audio') {
+    if (kind == 'RtcOutboundRtpStreamStatsMediaType_AudioImpl') {
       var cast =
           stats.mediaType as ffi.RtcOutboundRtpStreamStatsMediaType_Audio;
       mediaType = RtcOutboundRtpStreamStatsAudio(
           cast.totalSamplesSent, cast.voiceActivityFlag);
-    } else if (kind == 'RtcOutboundRtpStreamStatsKind_Video') {
+    } else if (kind == 'RtcOutboundRtpStreamStatsMediaType_VideoImpl') {
       var cast =
           stats.mediaType as ffi.RtcOutboundRtpStreamStatsMediaType_Video;
       mediaType = RtcOutboundRtpStreamStatsVideo(
@@ -919,7 +919,7 @@ class RtcInboundRtpStreamStats extends RtcStatsType {
       ffi.RtcStatsType_RtcInboundRtpStreamStats stats) {
     RtcInboundRtpStreamMediaType? mediaType;
     var type = stats.mediaType.runtimeType.toString().substring(2);
-    if (type == 'RtcInboundRtpStreamMediaType_Audio') {
+    if (type == 'RtcInboundRtpStreamMediaType_AudioImpl') {
       var cast = stats.mediaType as ffi.RtcInboundRtpStreamMediaType_Audio;
       mediaType = RtcInboundRtpStreamAudio(
           cast.totalSamplesReceived,
@@ -929,7 +929,7 @@ class RtcInboundRtpStreamStats extends RtcStatsType {
           cast.totalAudioEnergy,
           cast.totalSamplesDuration,
           cast.voiceActivityFlag);
-    } else if (type == 'RtcInboundRtpStreamMediaType_Video') {
+    } else if (type == 'RtcInboundRtpStreamMediaType_VideoImpl') {
       var cast = stats.mediaType as ffi.RtcInboundRtpStreamMediaType_Video;
       mediaType = RtcInboundRtpStreamVideo(
         cast.framesDecoded,


### PR DESCRIPTION
Required for instrumentisto/medea-jason#173




## Synopsis

We have implementation of `RtcStats` getting for desktop platforms, but it works incorrectly in some cases. This PR fixes this problems.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
