### PR TITLE
Implement`PeerConnection.getStats()` for iOS

### DIFF
--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/model/RtcStats.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/model/RtcStats.kt
@@ -28,6 +28,7 @@ data class RtcStats(
 
   /** Converts these [RtcStats] into a [Map] which can be returned to the Flutter side. */
   fun asFlutterResult(): Map<String, Any> {
-    return mapOf("id" to id, "timestampUs" to timestampUs, "kind" to kind, "type" to type)
+    var report = mapOf("id" to id, "timestampUs" to timestampUs, "type" to type)
+    return report + kind
   }
 }

--- a/example/integration_test/webrtc_test.dart
+++ b/example/integration_test/webrtc_test.dart
@@ -1186,10 +1186,6 @@ void main() {
   });
 
   testWidgets('Peer connection get stats.', (WidgetTester tester) async {
-    // TODO: Support stats for iOS platform.
-    if (Platform.isIOS) {
-      return;
-    }
     var pc1 = await PeerConnection.create(IceTransportType.all, []);
     var pc2 = await PeerConnection.create(IceTransportType.all, []);
 

--- a/ios/Classes/controller/PeerConnectionController.swift
+++ b/ios/Classes/controller/PeerConnectionController.swift
@@ -139,6 +139,30 @@ class PeerConnectionController {
           self.sendResultFromTask(result, getFlutterError(error))
         }
       }
+    case "getStats":
+      Task {
+        do {
+          let report = try await self.peer.getStats()
+
+          var statsList: [[String: Any]] = []
+          for (_, stats) in report.statistics {
+            var statDetails: [String: Any] = [:]
+            statDetails["id"] = stats.id
+            statDetails["type"] = stats.type
+            statDetails["timestampUs"] = Int(stats.timestamp_us * 1000.0)
+
+            for (statName, statValue) in stats.values {
+              statDetails[statName] = statValue
+            }
+
+            statsList.append(statDetails)
+          }
+
+          self.sendResultFromTask(result, statsList)
+        } catch {
+          self.sendResultFromTask(result, getFlutterError(error))
+        }
+      }
     case "addTransceiver":
       let mediaType = argsMap!["mediaType"] as? Int
       let initArgs = argsMap!["init"] as? [String: Any]

--- a/ios/Classes/controller/PeerConnectionController.swift
+++ b/ios/Classes/controller/PeerConnectionController.swift
@@ -143,22 +143,7 @@ class PeerConnectionController {
       Task {
         do {
           let report = try await self.peer.getStats()
-
-          var statsList: [[String: Any]] = []
-          for (_, stats) in report.statistics {
-            var statDetails: [String: Any] = [:]
-            statDetails["id"] = stats.id
-            statDetails["type"] = stats.type
-            statDetails["timestampUs"] = Int(stats.timestamp_us * 1000.0)
-
-            for (statName, statValue) in stats.values {
-              statDetails[statName] = statValue
-            }
-
-            statsList.append(statDetails)
-          }
-
-          self.sendResultFromTask(result, statsList)
+          self.sendResultFromTask(result, report.asFlutterResult())
         } catch {
           self.sendResultFromTask(result, getFlutterError(error))
         }

--- a/ios/Classes/model/RtcStats.swift
+++ b/ios/Classes/model/RtcStats.swift
@@ -1,0 +1,22 @@
+class RtcStats {
+  var statsList: [[String: Any]] = []
+
+  init(report: RTCStatisticsReport) {
+    for (_, stats) in report.statistics {
+      var statDetails: [String: Any] = [:]
+      statDetails["id"] = stats.id
+      statDetails["type"] = stats.type
+      statDetails["timestampUs"] = Int(stats.timestamp_us * 1000.0)
+
+      for (statName, statValue) in stats.values {
+        statDetails[statName] = statValue
+      }
+
+      self.statsList.append(statDetails)
+    }
+  }
+
+  func asFlutterResult() -> [[String: Any]] {
+    return self.statsList
+  }
+}

--- a/ios/Classes/model/RtcStats.swift
+++ b/ios/Classes/model/RtcStats.swift
@@ -1,6 +1,9 @@
+/// Representation of `RTCStatisticsReport`.
 class RtcStats {
+  /// List of all RTC stats reports converted to flat `Map`.
   var statsList: [[String: Any]] = []
 
+  /// Converts the provided `RTCStatisticsReport` into `RtcStats`.
   init(report: RTCStatisticsReport) {
     for (_, stats) in report.statistics {
       var statDetails: [String: Any] = [:]
@@ -16,6 +19,8 @@ class RtcStats {
     }
   }
 
+  /// Converts these `RtcStats` into a `Map` which can be returned to the
+  /// Flutter side.
   func asFlutterResult() -> [[String: Any]] {
     return self.statsList
   }

--- a/ios/Classes/proxy/PeerConnectionProxy.swift
+++ b/ios/Classes/proxy/PeerConnectionProxy.swift
@@ -41,8 +41,12 @@ class PeerConnectionProxy {
 
   func getStats() async throws -> RtcStats {
     return try await withCheckedThrowingContinuation { continuation in
-      self.peer.statistics { (report: RTCStatisticsReport) in
-        continuation.resume(returning: RtcStats(report: report))
+      do {
+        try self.peer.statistics { report in
+          continuation.resume(returning: RtcStats(report: report))
+        }
+      } catch {
+        continuation.resume(throwing: error)
       }
     }
   }

--- a/ios/Classes/proxy/PeerConnectionProxy.swift
+++ b/ios/Classes/proxy/PeerConnectionProxy.swift
@@ -39,6 +39,14 @@ class PeerConnectionProxy {
     self.id
   }
 
+  func getStats() async throws -> RTCStatisticsReport {
+    return try await withCheckedThrowingContinuation { continuation in
+      self.peer.statistics { (report: RTCStatisticsReport) in
+        continuation.resume(returning: report)
+      }
+    }
+  }
+
   /// Synchronizes and returns all the `RtpTransceiverProxy`s of this
   /// `PeerConnectionProxy`.
   func getTransceivers() -> [RtpTransceiverProxy] {

--- a/ios/Classes/proxy/PeerConnectionProxy.swift
+++ b/ios/Classes/proxy/PeerConnectionProxy.swift
@@ -39,10 +39,10 @@ class PeerConnectionProxy {
     self.id
   }
 
-  func getStats() async throws -> RTCStatisticsReport {
+  func getStats() async throws -> RtcStats {
     return try await withCheckedThrowingContinuation { continuation in
       self.peer.statistics { (report: RTCStatisticsReport) in
-        continuation.resume(returning: report)
+        continuation.resume(returning: RtcStats(report: report))
       }
     }
   }

--- a/ios/Classes/proxy/PeerConnectionProxy.swift
+++ b/ios/Classes/proxy/PeerConnectionProxy.swift
@@ -39,6 +39,7 @@ class PeerConnectionProxy {
     self.id
   }
 
+  /// Returns `RtcStats` of this `PeerConnectionProxy`.
   func getStats() async throws -> RtcStats {
     return try await withCheckedThrowingContinuation { continuation in
       do {

--- a/lib/src/api/peer.dart
+++ b/lib/src/api/peer.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
-import 'dart:convert';
 
 import 'package:flutter/services.dart';
 
@@ -457,7 +456,6 @@ class _PeerConnectionChannel extends PeerConnection {
   Future<List<RtcStats>> getStats() async {
     List<dynamic> stats = await _chan.invokeMethod('getStats');
     List<RtcStats> result = List.empty(growable: true);
-    // print(jsonEncode(stats));
 
     for (var s in stats) {
       var stat = RtcStats.fromMap(s);

--- a/lib/src/api/peer.dart
+++ b/lib/src/api/peer.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:ffi';
 import 'dart:io';
+import 'dart:convert';
 
 import 'package:flutter/services.dart';
 
@@ -456,6 +457,7 @@ class _PeerConnectionChannel extends PeerConnection {
   Future<List<RtcStats>> getStats() async {
     List<dynamic> stats = await _chan.invokeMethod('getStats');
     List<RtcStats> result = List.empty(growable: true);
+    // print(jsonEncode(stats));
 
     for (var s in stats) {
       var stat = RtcStats.fromMap(s);

--- a/lib/src/model/stats.dart
+++ b/lib/src/model/stats.dart
@@ -54,7 +54,6 @@ class RtcStats {
 
   /// Creates [RTCStats] basing on the [Map] received from the native side.
   static RtcStats? fromMap(dynamic stats) {
-    // stats['kind']['type'] = stats['type'];
     var kind = RtcStatsType.fromMap(stats);
     if (kind == null) {
       return null;

--- a/lib/src/model/stats.dart
+++ b/lib/src/model/stats.dart
@@ -54,8 +54,8 @@ class RtcStats {
 
   /// Creates [RTCStats] basing on the [Map] received from the native side.
   static RtcStats? fromMap(dynamic stats) {
-    stats['kind']['type'] = stats['type'];
-    var kind = RtcStatsType.fromMap(stats['kind']);
+    // stats['kind']['type'] = stats['type'];
+    var kind = RtcStatsType.fromMap(stats);
     if (kind == null) {
       return null;
     } else {


### PR DESCRIPTION
## Synopsis

We have implementation of `PeerConnection.getStats()` for all platforms except iOS. So this PR adds support for them on that platform.




## Solution

Convert WebRTC `RTCStatisticsReport` object to flat map which can be send though Flutter channel.

Solution for iOS will work the same way as it implemented for Android.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
