### PR TITLE
Fix RtpReceiver use after free on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All user visible changes to this project will be documented in this file. This p
 - Unexpected audio category on `setOutputAudioId` call on [iOS]. ([#146])
 - Race condition bug on `setOutputAudioId` call on [Android]. ([#146])
 - Race condition bug on input/output device switch on desktop platforms. ([#151])
+- `RtpReceiver` use after free on [Android]. ([#165])
 
 [#137]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/137
 [#139]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/139
@@ -47,6 +48,7 @@ All user visible changes to this project will be documented in this file. This p
 [#156]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/156
 [#162]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/162
 [#164]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/164
+[#165]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/165
 [`dart:html`]: https://dart.dev/libraries/dart-html
 [`package:web`]: https://pub.dev/packages/web
 [126.0.6478.182-r2]: https://github.com/instrumentisto/libwebrtc-bin/releases/tag/126.0.6478.182-r2

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/proxy/PeerObserver.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/proxy/PeerObserver.kt
@@ -66,10 +66,16 @@ class PeerObserver : PeerConnection.Observer {
     if (transceiver != null && peer != null) {
       if (!peer!!.disposed) {
         Handler(Looper.getMainLooper()).post {
-          val receiver = transceiver.receiver
+          val receiverId: String
+          try {
+            receiverId = transceiver.receiver.id()
+          } catch (e: IllegalStateException) {
+            // Receiver is dead already - exit callback.
+            return@post
+          }
           val transceivers = peer?.getTransceivers()!!
           for (trans in transceivers) {
-            if (trans.receiver.id == receiver.id()) {
+            if (trans.receiver.id == receiverId) {
               peer?.observableEventBroadcaster()?.onTrack(trans.receiver.track, trans)
             }
           }

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/proxy/PeerObserver.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/proxy/PeerObserver.kt
@@ -65,14 +65,8 @@ class PeerObserver : PeerConnection.Observer {
   override fun onTrack(transceiver: RtpTransceiver?) {
     if (transceiver != null && peer != null) {
       if (!peer!!.disposed) {
+        val receiverId = transceiver.receiver.id()
         Handler(Looper.getMainLooper()).post {
-          val receiverId: String
-          try {
-            receiverId = transceiver.receiver.id()
-          } catch (e: IllegalStateException) {
-            // Receiver is dead already - exit callback.
-            return@post
-          }
           val transceivers = peer?.getTransceivers()!!
           for (trans in transceivers) {
             if (trans.receiver.id == receiverId) {


### PR DESCRIPTION
## Synopsis
```
Shutting down VM
FATAL EXCEPTION: main
Process: com.instrumentisto.medea_jason_example, PID: 2160
java.lang.IllegalStateException: RtpReceiver has been disposed.
  at org.webrtc.RtpReceiver.checkRtpReceiverExists(RtpReceiver.java:86)
  at org.webrtc.RtpReceiver.id(RtpReceiver.java:48)
  at com.instrumentisto.medea_flutter_webrtc.proxy.PeerObserver.onTrack$lambda-5(PeerObserver.kt:72)
  at com.instrumentisto.medea_flutter_webrtc.proxy.PeerObserver.$r8$lambda$WDlx3s_cMBVUMU8Z78fPRNKjgGY(Unknown Source:0)
  at com.instrumentisto.medea_flutter_webrtc.proxy.PeerObserver$$ExternalSyntheticLambda4.run(Unknown Source:4)
  at android.os.Handler.handleCallback(Handler.java:938)
  at android.os.Handler.dispatchMessage(Handler.java:99)
  at android.os.Looper.loopOnce(Looper.java:201)
  at android.os.Looper.loop(Looper.java:288)
  at android.app.ActivityThread.main(ActivityThread.java:7839)
  at java.lang.reflect.Method.invoke(Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
