### PR TITLE
Fix `AVAudioSession` activation in push notification context  on iOS (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Fixed
 
-- `AVAudioSession` activation in push notification context on iOS. ([#175])
+- `AVAudioSession` activation in push notification context on [iOS]. ([#175])
 
 [#172]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/172
 [#173]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/173

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,13 @@ All user visible changes to this project will be documented in this file. This p
 
 - Upgraded `flutter_rust_bridge` to 2.4.0 version. ([#172])
 
+### Fixed
+
+- `AVAudioSession` activation in push notification context on iOS. ([#175])
+
 [#172]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/172
 [#173]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/173
+[#175]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/175
 
 
 

--- a/ios/Classes/MediaDevices.swift
+++ b/ios/Classes/MediaDevices.swift
@@ -18,7 +18,7 @@ class MediaDevices {
       AVAudioSession.Category.playAndRecord,
       options: AVAudioSession.CategoryOptions.allowBluetooth
     )
-    try! AVAudioSession.sharedInstance().setActive(true)
+    try? AVAudioSession.sharedInstance().setActive(true)
     self.state = state
     NotificationCenter.default.addObserver(
       forName: AVAudioSession.routeChangeNotification, object: nil,

--- a/ios/Classes/MediaDevices.swift
+++ b/ios/Classes/MediaDevices.swift
@@ -14,7 +14,7 @@ class MediaDevices {
   /// Subscribes on `AVAudioSession.routeChangeNotification` notifications for
   /// `onDeviceChange` callback firing.
   init(state: State) {
-    try! AVAudioSession.sharedInstance().setCategory(
+    try? AVAudioSession.sharedInstance().setCategory(
       AVAudioSession.Category.playAndRecord,
       options: AVAudioSession.CategoryOptions.allowBluetooth
     )


### PR DESCRIPTION
Resolves #174




## Synopsis

Read #174 issue.




## Solution

Use `try?` instead of `try!` in `AVAudioSession` activation.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
