### PR TITLE
Fix `rtpReceiverCapabilities` support on iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -26,9 +26,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  instrumentisto-libwebrtc-bin: 146854184f62ca80d79ff3d95bf9446eff5e54a9
-  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
-  medea_flutter_webrtc: 37c4a65c3d4709bea5a612f655c79b4cf143cee7
+  instrumentisto-libwebrtc-bin: 9504c2bb2f3c154b786fe04a5af96f482199e2c1
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  medea_flutter_webrtc: 548ab4d92a67af6e9d5de3e1d13d5c45f04ad403
 
 PODFILE CHECKSUM: be3ab4e988bb308d23906be69146fcbef66fac55
 

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/ios/Classes/proxy/PeerConnectionFactoryProxy.swift
+++ b/ios/Classes/proxy/PeerConnectionFactoryProxy.swift
@@ -1,5 +1,40 @@
 import WebRTC
 
+/// Returns `RtpCapabilities` based on the provided `RTCRtpCapabilities`.
+private func rtpCapabilities(capabilities: RTCRtpCapabilities)
+  -> RtpCapabilities
+{
+  return RtpCapabilities(
+    codecs: capabilities.codecs.map { codec -> CodecCapability in
+      var preferredPayloadType: Int = (codec.preferredPayloadType != nil) ?
+        Int(codec.preferredPayloadType!) : 0
+      var kind = MediaType.fromString(kind: codec.kind)!
+      var clockRate = (codec.clockRate != nil) ? Int(codec.clockRate!) : 0
+      var numChannels: Int? = (codec.numChannels != nil) ?
+        Int(codec.numChannels!) : nil
+      return CodecCapability(
+        preferredPayloadType: preferredPayloadType,
+        name: codec.name,
+        kind: kind,
+        clockRate: clockRate,
+        numChannels: numChannels,
+        parameters: codec.parameters,
+        mimeType: codec.mimeType
+      )
+    },
+    headerExtensions: capabilities.headerExtensions
+      .map { header -> HeaderExtensionCapability in
+        var preferredId =
+          (header.preferredId != nil) ? Int(header.preferredId!) : nil
+        return HeaderExtensionCapability(
+          uri: header.uri,
+          preferredId: preferredId,
+          preferredEncrypted: header.isPreferredEncrypted
+        )
+      }
+  )
+}
+
 /// Creator of new `PeerConnectionProxy`s.
 class PeerConnectionFactoryProxy {
   /// Counter for generating new [PeerConnectionProxy] IDs.
@@ -21,41 +56,18 @@ class PeerConnectionFactoryProxy {
 
   /// Returns sender capabilities of this factory.
   func rtpSenderCapabilities(kind: RTCRtpMediaType) -> RtpCapabilities {
-    var capabilities =
-      self.factory
-        .rtpSenderCapabilities(
-          forKind: MediaType.fromWebRtc(kind: kind)!.toString()
-        )
+    return rtpCapabilities(capabilities: self.factory
+      .rtpSenderCapabilities(
+        forKind: MediaType.fromWebRtc(kind: kind)!.toString()
+      ))
+  }
 
-    return RtpCapabilities(
-      codecs: capabilities.codecs.map { codec -> CodecCapability in
-        var preferredPayloadType: Int = (codec.preferredPayloadType != nil) ?
-          Int(codec.preferredPayloadType!) : 0
-        var kind = MediaType.fromString(kind: codec.kind)!
-        var clockRate = (codec.clockRate != nil) ? Int(codec.clockRate!) : 0
-        var numChannels: Int? = (codec.numChannels != nil) ?
-          Int(codec.numChannels!) : nil
-        return CodecCapability(
-          preferredPayloadType: preferredPayloadType,
-          name: codec.name,
-          kind: kind,
-          clockRate: clockRate,
-          numChannels: numChannels,
-          parameters: codec.parameters,
-          mimeType: codec.mimeType
-        )
-      },
-      headerExtensions: capabilities.headerExtensions
-        .map { header -> HeaderExtensionCapability in
-          var preferredId =
-            (header.preferredId != nil) ? Int(header.preferredId!) : nil
-          return HeaderExtensionCapability(
-            uri: header.uri,
-            preferredId: preferredId,
-            preferredEncrypted: header.isPreferredEncrypted
-          )
-        }
-    )
+  /// Returns receiver capabilities of this factory.
+  func rtpReceiverCapabilities(kind: RTCRtpMediaType) -> RtpCapabilities {
+    return rtpCapabilities(capabilities: self.factory
+      .rtpReceiverCapabilities(
+        forKind: MediaType.fromWebRtc(kind: kind)!.toString()
+      ))
   }
 
   /// Creates a new `PeerConnectionProxy` based on the provided

--- a/ios/Classes/proxy/PeerConnectionFactoryProxy.swift
+++ b/ios/Classes/proxy/PeerConnectionFactoryProxy.swift
@@ -37,7 +37,7 @@ private func rtpCapabilities(capabilities: RTCRtpCapabilities)
 
 /// Creator of new `PeerConnectionProxy`s.
 class PeerConnectionFactoryProxy {
-  /// Counter for generating new [PeerConnectionProxy] IDs.
+  /// Counter for generating new `PeerConnectionProxy` IDs.
   private var lastPeerConnectionId: Int = 0
 
   /// All the `PeerObserver`s created by this `PeerConnectionFactoryProxy`.
@@ -93,7 +93,7 @@ class PeerConnectionFactoryProxy {
     return peerProxy
   }
 
-  /// Removes the specified [PeerObserver] from the [peerObservers].
+  /// Removes the specified `PeerObserver` from the `peerObservers`.
   private func remotePeerObserver(id: Int) {
     self.peerObservers.removeValue(forKey: id)
   }

--- a/ios/Classes/proxy/RtpReceiverProxy.swift
+++ b/ios/Classes/proxy/RtpReceiverProxy.swift
@@ -2,7 +2,7 @@ import WebRTC
 
 /// Wrapper around an `RTCRtpReceiver`, powering it with additional API.
 class RtpReceiverProxy {
-  /// Actual underlying [RtpReceiver].
+  /// Actual underlying `RTCRtpReceiver`.
   private var receiver: RTCRtpReceiver
 
   /// `MediaStreamTrackProxy` of this `RtpReceiverProxy`.


### PR DESCRIPTION
Related to #173




## Synopsis

In #173 was added method for getting `rtpReceiverCapabilities` on iOS, but part of this implementation is missing, so this functional doesn't work.




## Solution

Implement `PeerConnectionFactoryProxy::rtpReceiverCapabilities` the same way as `PeerConnectionFactoryProxy::rtpSenderCapabilities`.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
