### PR TITLE
Upgrade OpenAL to 1.24.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           - windows
     runs-on: ${{ (matrix.platform == 'macos'   && 'macos-12')
               || (matrix.platform == 'windows' && 'windows-latest')
-              ||                                  'ubuntu-latest' }}
+              ||                                  'ubuntu-20.04' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Changed
 
-- Upgraded [OpenAL] library to [1.24.1][openal-1.24.1] version. ([#181], [#???])
+- Upgraded [OpenAL] library to [1.24.1][openal-1.24.1] version. ([#181], [#182])
 
 [#181]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/181
-[#???]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/???
+[#182]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/182
 [openal-1.24.1]: https://github.com/kcat/openal-soft/releases/tag/1.24.1
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-## [0.11.3] · Unreleased
+## [0.11.3] · unreleased
 [0.11.3]: https://github.com/instrumentisto/medea-flutter-webrtc/tree/0.11.3
 
 [Diff](https://github.com/instrumentisto/medea-flutter-webrtc/compare/0.11.2...0.11.3)
 
 ### Changed
 
-- Upgraded [OpenAL] library to [1.24.1][openal-1.24.1] version. ([#181], [#182])
+- Upgraded [OpenAL] library to [1.24.1][openal-1.24.1] version. ([#182], [#181])
 - Upgraded [libwebrtc] to [131.0.6778.85-r1] version. ([#180])
 
 [#180]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,11 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Changed
 
-- Upgraded [OpenAL] library to [1.24.0][openal-1.24.0] version. ([#181])
+- Upgraded [OpenAL] library to [1.24.1][openal-1.24.1] version. ([#181], [#???])
 
 [#181]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/181
-[openal-1.24.0]: https://github.com/kcat/openal-soft/releases/tag/1.24.0
+[#???]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/???
+[openal-1.24.1]: https://github.com/kcat/openal-soft/releases/tag/1.24.1
 
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Medea Flutter-WebRTC
 
 [![pub](https://img.shields.io/pub/v/medea_flutter_webrtc "pub")](https://pub.dev/packages/medea_flutter_webrtc)
 [![libwebrtc](https://img.shields.io/badge/libwebrtc-130.0.6723.69-blue "libwebrtc")](https://github.com/instrumentisto/libwebrtc-bin/releases/tag/130.0.6723.69)
-[![OpenAL](https://img.shields.io/badge/OpenAL-1.24.0-blue "OpenAL")](https://github.com/kcat/openal-soft/releases/tag/1.24.0)
+[![OpenAL](https://img.shields.io/badge/OpenAL-1.24.1-blue "OpenAL")](https://github.com/kcat/openal-soft/releases/tag/1.24.1)
 
 [Changelog](https://github.com/instrumentisto/medea-flutter-webrtc/blob/main/CHANGELOG.md)
 

--- a/crates/libwebrtc-sys/build.rs
+++ b/crates/libwebrtc-sys/build.rs
@@ -31,7 +31,7 @@ static LIBWEBRTC_URL: &str =
 
 /// URL for downloading `openal-soft` source code.
 static OPENAL_URL: &str =
-    "https://github.com/kcat/openal-soft/archive/refs/tags/1.24.0";
+    "https://github.com/kcat/openal-soft/archive/refs/tags/1.24.1";
 
 fn main() -> anyhow::Result<()> {
     let lib_dir = libpath()?;


### PR DESCRIPTION
## Synopsis

New versions of OpenAL [was released](https://github.com/kcat/openal-soft/releases/tag/1.24.1).




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
