### PR TITLE
Upgrade libwebrtc 132.0.6834.83

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ All user visible changes to this project will be documented in this file. This p
 ### Changed
 
 - Upgraded [OpenAL] library to [1.24.2][openal-1.24.2] version. ([todo])
-- Upgraded [libwebrtc] to [132.0.6834.83] version. ([todo])
+- Upgraded [libwebrtc] to [132.0.6834.83] version. ([#184])
 
+[#184]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/184
 [todo]: https://github.com/instrumentisto/medea-flutter-webrtc/commit/todo
 [132.0.6834.83]: https://github.com/instrumentisto/libwebrtc-bin/releases/tag/132.0.6834.83
 [openal-1.24.2]: https://github.com/kcat/openal-soft/releases/tag/1.24.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ All user visible changes to this project will be documented in this file. This p
 ### Changed
 
 - Upgraded [OpenAL] library to [1.24.2][openal-1.24.2] version. ([todo])
-- Upgraded [libwebrtc] to [131.0.6778.264] version. ([todo])
+- Upgraded [libwebrtc] to [132.0.6834.83] version. ([todo])
 
 [todo]: https://github.com/instrumentisto/medea-flutter-webrtc/commit/todo
-[131.0.6778.264]: https://github.com/instrumentisto/libwebrtc-bin/releases/tag/131.0.6778.264
+[132.0.6834.83]: https://github.com/instrumentisto/libwebrtc-bin/releases/tag/132.0.6834.83
 [openal-1.24.2]: https://github.com/kcat/openal-soft/releases/tag/1.24.2
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "libwebrtc-sys"
-version = "0.0.0+131.0.6778.264"
+version = "0.0.0+132.0.6834.83"
 dependencies = [
  "anyhow",
  "cxx",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Medea Flutter-WebRTC
 ====================
 
 [![pub](https://img.shields.io/pub/v/medea_flutter_webrtc "pub")](https://pub.dev/packages/medea_flutter_webrtc)
-[![libwebrtc](https://img.shields.io/badge/libwebrtc-131.0.6778.264-blue "libwebrtc")](https://github.com/instrumentisto/libwebrtc-bin/releases/tag/131.0.6778.264)
+[![libwebrtc](https://img.shields.io/badge/libwebrtc-132.0.6834.83-blue "libwebrtc")](https://github.com/instrumentisto/libwebrtc-bin/releases/tag/132.0.6834.83)
 [![OpenAL](https://img.shields.io/badge/OpenAL-1.24.2-blue "OpenAL")](https://github.com/kcat/openal-soft/releases/tag/1.24.2)
 
 [Changelog](https://github.com/instrumentisto/medea-flutter-webrtc/blob/main/CHANGELOG.md)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -60,7 +60,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.github.instrumentisto:libwebrtc-bin:131.0.6778.264@aar'
+    implementation 'com.github.instrumentisto:libwebrtc-bin:132.0.6834.83@aar'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 }

--- a/crates/libwebrtc-sys/Cargo.toml
+++ b/crates/libwebrtc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libwebrtc-sys"
-version = "0.0.0+131.0.6778.264"
+version = "0.0.0+132.0.6834.83"
 edition = "2021"
 rust-version = "1.81"
 publish = false

--- a/crates/libwebrtc-sys/build.rs
+++ b/crates/libwebrtc-sys/build.rs
@@ -27,7 +27,7 @@ use walkdir::{DirEntry, WalkDir};
 /// [`libwebrtc-bin`]: https://github.com/instrumentisto/libwebrtc-bin
 static LIBWEBRTC_URL: &str =
     "https://github.com/instrumentisto/libwebrtc-bin/releases/download\
-                                                    /131.0.6778.264";
+                                                    /132.0.6834.83";
 
 /// URL for downloading `openal-soft` source code.
 static OPENAL_URL: &str =
@@ -124,19 +124,19 @@ fn get_target() -> anyhow::Result<String> {
 fn get_expected_libwebrtc_hash() -> anyhow::Result<&'static str> {
     Ok(match get_target()?.as_str() {
         "aarch64-unknown-linux-gnu" => {
-            "288cde042e429e53240e7859d4b7c7f54b24f8ced6f82127b312feb4b2bec92f"
+            "77628785dea683f429859e104545ff1bc11688d64cc18287fc2398780384c824"
         }
         "x86_64-unknown-linux-gnu" => {
-            "fa9723606aa5cb7bc63ceb8a1ed264e2c73508a8e9a8a167f6493810427137e9"
+            "57495434973561c61a3bab5fcdfb45b59510995edc7f65001889f4aac3d8cad0"
         }
         "aarch64-apple-darwin" => {
-            "860205dd9a555b38113abc6dc250d5f4c032c82886175f6307f31fbea2d8b0e3"
+            "0e51a5c30b580e4c9554ea64ed5b24ca47580c02385c3c590dea390d3e2f8599"
         }
         "x86_64-apple-darwin" => {
-            "08b8aa369d2798aeb987bbde010739b7292e7e8df912dfc907f19a7be6f4e6ac"
+            "6eb7617972410d586dcf729028d08c6634d841bfcc74bc7d35a2b31591a3950a"
         }
         "x86_64-pc-windows-msvc" => {
-            "2ffa419baba47572b0e7ddaf2dce52ceef488c2ece1cd8550e349561b31eb02c"
+            "36bfdb25e85d18f06c32580daf66eb52d1cc82e2426b07b50f0ecd568964a291"
         }
         arch => return Err(anyhow::anyhow!("Unsupported target: {arch}")),
     })

--- a/example/integration_test/webrtc_test.dart
+++ b/example/integration_test/webrtc_test.dart
@@ -307,7 +307,7 @@ void main() {
     ];
 
     for (var mimeType in mimeTypes) {
-    print("mimeType: $mimeType");
+      print("mimeType: $mimeType");
       expect(
           senderCapabilities.codecs
               .where((cap) => cap.mimeType == mimeType)

--- a/example/integration_test/webrtc_test.dart
+++ b/example/integration_test/webrtc_test.dart
@@ -307,6 +307,7 @@ void main() {
     ];
 
     for (var mimeType in mimeTypes) {
+      // ignore: avoid_print
       print("mimeType: $mimeType");
       expect(
           senderCapabilities.codecs

--- a/example/integration_test/webrtc_test.dart
+++ b/example/integration_test/webrtc_test.dart
@@ -299,7 +299,6 @@ void main() {
       'audio/opus',
       'audio/red',
       'audio/G722',
-//       'audio/ILBC',
       'audio/PCMU',
       'audio/PCMA',
       'audio/CN',
@@ -307,8 +306,6 @@ void main() {
     ];
 
     for (var mimeType in mimeTypes) {
-      // ignore: avoid_print
-      print("mimeType: $mimeType");
       expect(
           senderCapabilities.codecs
               .where((cap) => cap.mimeType == mimeType)

--- a/example/integration_test/webrtc_test.dart
+++ b/example/integration_test/webrtc_test.dart
@@ -299,7 +299,7 @@ void main() {
       'audio/opus',
       'audio/red',
       'audio/G722',
-      'audio/ILBC',
+//       'audio/ILBC',
       'audio/PCMU',
       'audio/PCMA',
       'audio/CN',
@@ -307,6 +307,7 @@ void main() {
     ];
 
     for (var mimeType in mimeTypes) {
+    print("mimeType: $mimeType");
       expect(
           senderCapabilities.codecs
               .where((cap) => cap.mimeType == mimeType)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - Flutter (1.0.0)
-  - instrumentisto-libwebrtc-bin (131.0.6778.264)
+  - instrumentisto-libwebrtc-bin (132.0.6834.83)
   - integration_test (0.0.1):
     - Flutter
   - medea_flutter_webrtc (0.12.0):
     - Flutter
-    - instrumentisto-libwebrtc-bin (= 131.0.6778.264)
+    - instrumentisto-libwebrtc-bin (= 132.0.6834.83)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -26,10 +26,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  instrumentisto-libwebrtc-bin: 78f04b57eb472ef1aacaa77b4a2be4c680190811
+  instrumentisto-libwebrtc-bin: e6f43438d40cab84d6233665c43dd05b5ac76428
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
-  medea_flutter_webrtc: a39eb474e34d3c29c4f669821189a16e085cd141
+  medea_flutter_webrtc: d1f3f2ea89548a4ceff3183bf4a7cc62e6927053
 
 PODFILE CHECKSUM: be3ab4e988bb308d23906be69146fcbef66fac55
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.14.3

--- a/ios/medea_flutter_webrtc.podspec
+++ b/ios/medea_flutter_webrtc.podspec
@@ -15,7 +15,7 @@ Flutter WebRTC plugin based on Google WebRTC.
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'instrumentisto-libwebrtc-bin', '131.0.6778.264'
+  s.dependency 'instrumentisto-libwebrtc-bin', '132.0.6834.83'
   s.platform         = :ios, '13.0'
   s.static_framework = true
 


### PR DESCRIPTION
## Synopsis

libwebrtc 132.0.6834.83 was released, so we need to update it in `flutter-webrtc`.





## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
