### PR TITLE
Replace `dart:ui` with `dart:ui_web` in Dart sources

### DIFF
--- a/lib/src/platform/web/video_renderer.dart
+++ b/lib/src/platform/web/video_renderer.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
-import 'dart:ui' as ui;
+import 'dart:ui_web' as ui;
 
 import 'package:flutter/services.dart';
 
@@ -189,7 +189,6 @@ class WebVideoRenderer extends VideoRenderer {
 
   @override
   Future<void> initialize() async {
-    // ignore: undefined_prefixed_name
     ui.platformViewRegistry.registerViewFactory('RTCVideoRenderer-$textureId', (
       int viewId,
     ) {


### PR DESCRIPTION
## Synopsis

`platformViewRegistry` comes from the `dart:ui_web` library and not the `dart:ui`. Until Flutter 3.30 (master) this import was automatically considered as `dart:ui_web`, yet now it throws:
```
Target dart2wasm failed: ProcessException: Process exited abnormally with exit code 254:
../../../.pub-cache/hosted/pub.dev/medea_flutter_webrtc-0.12.2/lib/src/platform/web/video_renderer.dart:192:8: Error: Undefined name 'platformViewRegistry'.
    ui.platformViewRegistry.registerViewFactory('RTCVideoRenderer-$textureId',
       ^^^^^^^^^^^^^^^^^^^^
  Command: /opt/homebrew/Caskroom/flutter/3.29.0/flutter/bin/cache/dart-sdk/bin/dart compile wasm
```




## Solution

This PR replaces `dart:ui` with `dart:ui_web`, which seems to fix the issue:

<img width="1446" alt="Screenshot 2025-02-18 at 14 20 30" src="https://github.com/user-attachments/assets/1bd097e1-bcfd-465e-85b6-ea7f8dd9875b" />





## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
