### PR TITLE
Build linux artifacts in debian:bookworm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,8 @@ jobs:
   build-rust-linux:
     name: build-rust (linux)
     runs-on: ubuntu-latest
-    # Pin glibc to 2.28 for better compatibility.
-    container: debian:bullseye
+    # Pin glibc to 2.36 for better compatibility.
+    container: debian:bookworm
     steps:
       - name: Install Linux platform dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,9 +178,9 @@ jobs:
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | tee /etc/apt/sources.list.d/llvm.list
           apt-get update
           apt-get install -y \
-                       curl libssl-dev \
+                       cmake curl \
                        libpulse-dev libudev-dev libxcomposite-dev libxdamage-dev \
-                       libxfixes-dev libxrandr-dev libxtst-dev \
+                       libxfixes-dev libxrandr-dev libxtst-dev libssl-dev \
                        ninja-build binutils build-essential
 
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,9 +179,8 @@ jobs:
           apt-get update
           apt-get install -y \
                        cmake curl \
-                       libpulse-dev libudev-dev libxcomposite-dev libxdamage-dev \
-                       libxfixes-dev libxrandr-dev libxtst-dev libssl-dev \
-                       ninja-build binutils build-essential
+                       libgtk-3-dev liblzma-dev libpulse-dev libudev-dev \
+                       ninja-build lld-19 binutils build-essential
 
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Install Linux platform dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev
+          sudo apt-get install -y libgtk-3-dev libpulse-dev
         if: ${{ matrix.platform == 'linux' }}
 
       - run: flutter config --enable-${{ matrix.platform }}-desktop
@@ -220,11 +220,6 @@ jobs:
           path: windows/rust/
 
       - run: make flutter.build platform=${{ matrix.platform }}
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: build-${{ matrix.platform }}
-          path: ${{ matrix.platform }}/rust/
 
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
     name: build-rust (linux)
     runs-on: ubuntu-latest
     # Pin glibc to 2.28 for better compatibility.
-    container: debian:buster
+    container: debian:bullseye
     steps:
       - name: Install Linux platform dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
           apt-get install -y \
                        cmake curl \
                        libgtk-3-dev liblzma-dev libpulse-dev libudev-dev \
-                       ninja-build lld-19 binutils build-essential
+                       libssl-dev ninja-build lld-19 binutils build-essential
 
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,8 @@ jobs:
     steps:
       - name: Install Linux platform dependencies
         run: |
+          sudo apt-get update
+          sudo apt-get install -y wget
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm.asc
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,13 +137,15 @@ jobs:
   ############
 
   build-rust:
+    name: cargo build (${{ matrix.platform }})
     strategy:
       fail-fast: false
       matrix:
-        platform: ["macos", "windows"]
-    runs-on: ${{ (matrix.platform == 'macos'   && 'macos-13')
-              || (matrix.platform == 'windows' && 'windows-latest')
-              ||                                  'ubuntu-latest' }}
+        platform:
+          - macos
+          - windows
+    runs-on: ${{ (matrix.platform == 'macos' && 'macos-13')
+              ||                                'windows-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
@@ -161,26 +163,30 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.platform }}
+          name: build-rust-${{ matrix.platform }}
           path: ${{ matrix.platform }}/rust/
 
   build-rust-linux:
-    name: build-rust (linux)
+    name: cargo build (linux)
     runs-on: ubuntu-latest
-    # Pin glibc to 2.36 for better compatibility.
-    container: debian:bookworm
+    container: debian:bookworm  # pin `glibc` to 2.36 for better compatibility
     steps:
-      - name: Install Linux platform dependencies
+      - name: Install `linux` platform dependencies
         run: |
+          set -ex
+
           apt-get update
           apt-get install -y wget
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/llvm.asc
-          echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-19 main" | tee /etc/apt/sources.list.d/llvm.list
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key \
+          | tee /etc/apt/trusted.gpg.d/llvm.asc
+          echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-19 main" \
+          | tee /etc/apt/sources.list.d/llvm.list
+
           apt-get update
           apt-get install -y \
-                       cmake curl \
-                       libgtk-3-dev liblzma-dev libpulse-dev libudev-dev \
-                       libssl-dev ninja-build lld-19 binutils build-essential
+                  cmake curl \
+                  libgtk-3-dev liblzma-dev libpulse-dev libudev-dev \
+                  libssl-dev ninja-build lld-19 binutils build-essential
           update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
           update-alternatives --config lld
           update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-19 100
@@ -190,18 +196,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-
       - run: make rustup.targets only=linux
 
       - run: make cargo.build platform=linux debug=no
 
       - uses: actions/upload-artifact@v4
         with:
-          name: build-linux
+          name: build-rust-linux
           path: linux/rust/
 
-
   build-flutter:
+    name: flutter build (${{ matrix.platform }})
     needs: ["build-rust", "build-rust-linux"]
     strategy:
       fail-fast: false
@@ -211,23 +216,22 @@ jobs:
           - macos
           - windows
     runs-on: ${{ (matrix.platform == 'macos'   && 'macos-latest')
-      || (matrix.platform == 'windows' && 'windows-latest')
-      ||                                  'ubuntu-latest' }}
+              || (matrix.platform == 'windows' && 'windows-latest')
+              ||                                  'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
+      - run: flutter config --enable-${{ matrix.platform }}-desktop
 
-      - name: Install Linux platform dependencies
+      - name: Install `linux` platform dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libpulse-dev
         if: ${{ matrix.platform == 'linux' }}
 
-      - run: flutter config --enable-${{ matrix.platform }}-desktop
-
       - uses: actions/download-artifact@v4
         with:
-          name: build-${{ matrix.platform }}
+          name: build-rust-${{ matrix.platform }}
           path: ${{ matrix.platform }}/rust/
 
       - run: make flutter.build platform=${{ matrix.platform }}
@@ -280,10 +284,10 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: build-${{ matrix.platform }}
+          name: build-rust-${{ matrix.platform }}
           path: ${{ matrix.platform }}/rust/
         if: ${{ matrix.platform != 'android'
-          && matrix.platform != 'ios' }}
+             && matrix.platform != 'ios' }}
 
       - name: Test on `${{ matrix.platform }}` platform with emulator
         uses: reactivecircus/android-emulator-runner@v2
@@ -366,9 +370,9 @@ jobs:
           - linux
           - macos
           - windows
-    runs-on: ${{ (matrix.platform == 'linux' &&   'ubuntu-latest')
+    runs-on: ${{ (matrix.platform == 'macos'   && 'macos-latest')
               || (matrix.platform == 'windows' && 'windows-latest')
-              ||                                  'macos-latest' }}
+              ||                                  'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
@@ -461,17 +465,17 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: build-linux
+          name: build-rust-linux
           path: linux/rust/
         if: ${{ steps.skip.outputs.no == 'true' }}
       - uses: actions/download-artifact@v4
         with:
-          name: build-macos
+          name: build-rust-macos
           path: macos/rust/
         if: ${{ steps.skip.outputs.no == 'true' }}
       - uses: actions/download-artifact@v4
         with:
-          name: build-windows
+          name: build-rust-windows
           path: windows/rust/
         if: ${{ steps.skip.outputs.no == 'true' }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
                        cmake \
-                       liblzma-dev libpulse-dev libudev-dev \
+                       libxfixes3 liblzma-dev libpulse-dev libudev-dev \
                        ninja-build lld-19 binutils build-essential
           # TODO: Remove once lld-19 becomes the default in Ubuntu repositories
           sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,6 +272,12 @@ jobs:
         if: ${{ matrix.platform != 'android'
              && matrix.platform != 'ios' }}
 
+      - name: Install `${{ matrix.platform }}` platform dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libpulse-dev
+        if: ${{ matrix.platform == 'linux' }}
+
       - uses: actions/download-artifact@v4
         with:
           name: build-${{ matrix.platform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,7 @@ jobs:
 
   test-flutter:
     name: test (example, ${{ matrix.platform }})
+    needs: ["build-rust", "build-rust-linux"]
     strategy:
       fail-fast: false
       matrix:
@@ -276,20 +277,21 @@ jobs:
         if: ${{ matrix.platform != 'android'
              && matrix.platform != 'ios' }}
 
-      - name: Install `${{ matrix.platform }}` platform dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-                       cmake \
-                       libgtk-3-dev liblzma-dev libpulse-dev libudev-dev \
-                       ninja-build \
-                       xvfb lld-19 binutils build-essential
-          # TODO: Remove once lld-19 becomes the default in Ubuntu repositories
-          sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
-          sudo update-alternatives --config lld
-          sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-19 100
-          sudo update-alternatives --config ld.lld
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-linux
+          path: linux/rust/
         if: ${{ matrix.platform == 'linux' }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-macos
+          path: macos/rust/
+        if: ${{ matrix.platform == 'macos' }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-windows
+          path: windows/rust/
+        if: ${{ matrix.platform == 'windows' }}
 
       - run: make cargo.build debug=yes platform=${{ matrix.platform }}
         if: ${{ matrix.platform != 'android'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
                        cmake \
-                       libgtk-3-dev liblzma-dev libpulse-dev libudev-dev \
+                       liblzma-dev libpulse-dev libudev-dev \
                        ninja-build lld-19 binutils build-essential
           # TODO: Remove once lld-19 becomes the default in Ubuntu repositories
           sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
@@ -197,6 +197,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
+
+      - name: Install Linux platform dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev
+        if: ${{ matrix.platform == 'linux' }}
+
       - run: flutter config --enable-${{ matrix.platform }}-desktop
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     needs:
       - build-rust
+      - build-rust-linux
       - build-flutter
       - clippy
       - dartanalyze
@@ -139,19 +140,41 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux
-          - macos
-          - windows
+        platform: ["macos", "windows"]
     runs-on: ${{ (matrix.platform == 'macos'   && 'macos-13')
               || (matrix.platform == 'windows' && 'windows-latest')
-              ||                                  'ubuntu-22.04' }}
+              ||                                  'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
       - run: make rustup.targets only=${{ matrix.platform }}
+
+      # Pin Xcode version for better compatibility.
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "14.1"
+        if: ${{ matrix.platform == 'macos' }}
+
+      - run: make cargo.build platform=${{ matrix.platform }} debug=no
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.platform }}
+          path: ${{ matrix.platform }}/rust/
+
+  build-rust-linux:
+    name: build-rust (linux)
+    runs-on: ubuntu-latest
+    # Pin glibc to 2.28 for better compatibility.
+    container: debian:buster
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - run: make rustup.targets only=linux
 
       - name: Install Linux platform dependencies
         run: |
@@ -167,23 +190,17 @@ jobs:
           sudo update-alternatives --config lld
           sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-19 100
           sudo update-alternatives --config ld.lld
-        if: ${{ matrix.platform == 'linux' }}
 
-      # Pin Xcode version for better compatibility.
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "14.1"
-        if: ${{ matrix.platform == 'macos' }}
-
-      - run: make cargo.build platform=${{ matrix.platform }} debug=no
+      - run: make cargo.build platform=linux debug=no
 
       - uses: actions/upload-artifact@v4
         with:
-          name: build-${{ matrix.platform }}
-          path: ${{ matrix.platform }}/rust/
+          name: build-linux
+          path: linux/rust/
+
 
   build-flutter:
-    needs: ["build-rust"]
+    needs: ["build-rust", "build-rust-linux"]
     strategy:
       fail-fast: false
       matrix:
@@ -400,6 +417,7 @@ jobs:
              && github.event.pull_request.head.repo.owner.login == 'instrumentisto') }}
     needs:
       - build-rust
+      - build-rust-linux
       - build-flutter
       - clippy
       - dartanalyze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "linux-lower-reqs"]
     tags: ["*"]
   pull_request:
     branches: ["main"]
@@ -23,7 +23,8 @@ jobs:
   pr:
     if: ${{ github.event_name == 'pull_request' }}
     needs:
-      - build
+      - build-rust
+      - build-flutter
       - clippy
       - dartanalyze
       - dartfmt
@@ -134,7 +135,7 @@ jobs:
   # Building #
   ############
 
-  build:
+  build-rust:
     strategy:
       fail-fast: false
       matrix:
@@ -151,8 +152,6 @@ jobs:
         with:
           toolchain: stable
       - run: make rustup.targets only=${{ matrix.platform }}
-      - uses: subosito/flutter-action@v2
-      - run: flutter config --enable-${{ matrix.platform }}-desktop
 
       - name: Install Linux platform dependencies
         run: |
@@ -177,6 +176,42 @@ jobs:
         if: ${{ matrix.platform == 'macos' }}
 
       - run: make cargo.build platform=${{ matrix.platform }} debug=no
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.platform }}
+          path: ${{ matrix.platform }}/rust/
+
+  build-fultter:
+    needs: ["build-rust"]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux
+          - macos
+          - windows
+    runs-on: ${{ (matrix.platform == 'macos'   && 'macos-latest')
+      || (matrix.platform == 'windows' && 'windows-latest')
+      ||                                  'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+      - run: flutter config --enable-${{ matrix.platform }}-desktop
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-linux
+          path: linux/rust/
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-macos
+          path: macos/rust/
+      - uses: actions/download-artifact@v4
+        with:
+          name: build-windows
+          path: windows/rust/
+
       - run: make flutter.build platform=${{ matrix.platform }}
 
       - uses: actions/upload-artifact@v4
@@ -193,7 +228,6 @@ jobs:
 
   test-flutter:
     name: test (example, ${{ matrix.platform }})
-    needs: ["build"]
     strategy:
       fail-fast: false
       matrix:
@@ -363,7 +397,8 @@ jobs:
          || (github.event_name == 'pull_request'
              && github.event.pull_request.head.repo.owner.login == 'instrumentisto') }}
     needs:
-      - build
+      - build-rust
+      - build-flutter
       - clippy
       - dartanalyze
       - dartfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,8 @@ jobs:
         with:
           name: build-${{ matrix.platform }}
           path: ${{ matrix.platform }}/rust/
+        if: ${{ matrix.platform != 'android'
+          && matrix.platform != 'ios' }}
 
       - name: Test on `${{ matrix.platform }}` platform with emulator
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["main", "linux-lower-reqs"]
+    branches: ["main"]
     tags: ["*"]
   pull_request:
     branches: ["main"]
@@ -227,16 +227,8 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: build-linux
-          path: linux/rust/
-      - uses: actions/download-artifact@v4
-        with:
-          name: build-macos
-          path: macos/rust/
-      - uses: actions/download-artifact@v4
-        with:
-          name: build-windows
-          path: windows/rust/
+          name: build-${{ matrix.platform }}
+          path: ${{ matrix.platform }}/rust/
 
       - run: make flutter.build platform=${{ matrix.platform }}
 
@@ -282,23 +274,8 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: build-linux
-          path: linux/rust/
-        if: ${{ matrix.platform == 'linux' }}
-      - uses: actions/download-artifact@v4
-        with:
-          name: build-macos
-          path: macos/rust/
-        if: ${{ matrix.platform == 'macos' }}
-      - uses: actions/download-artifact@v4
-        with:
-          name: build-windows
-          path: windows/rust/
-        if: ${{ matrix.platform == 'windows' }}
-
-      - run: make cargo.build debug=yes platform=${{ matrix.platform }}
-        if: ${{ matrix.platform != 'android'
-             && matrix.platform != 'ios' }}
+          name: build-${{ matrix.platform }}
+          path: ${{ matrix.platform }}/rust/
 
       - name: Test on `${{ matrix.platform }}` platform with emulator
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,8 +159,8 @@ jobs:
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
           sudo apt-get install -y \
-                       cmake \
-                       libxfixes3 liblzma-dev libpulse-dev libudev-dev \
+                       libpulse-dev libudev-dev libxcomposite-dev libxdamage-dev \
+                       libxfixes-dev libxrandr-dev libxtst-dev \
                        ninja-build lld-19 binutils build-essential
           # TODO: Remove once lld-19 becomes the default in Ubuntu repositories
           sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,12 +175,16 @@ jobs:
           apt-get update
           apt-get install -y wget
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/llvm.asc
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | tee /etc/apt/sources.list.d/llvm.list
+          echo "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-19 main" | tee /etc/apt/sources.list.d/llvm.list
           apt-get update
           apt-get install -y \
                        cmake curl \
                        libgtk-3-dev liblzma-dev libpulse-dev libudev-dev \
                        libssl-dev ninja-build lld-19 binutils build-essential
+          update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
+          update-alternatives --config lld
+          update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-19 100
+          update-alternatives --config ld.lld
 
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,12 +181,7 @@ jobs:
                        curl \
                        libpulse-dev libudev-dev libxcomposite-dev libxdamage-dev \
                        libxfixes-dev libxrandr-dev libxtst-dev \
-                       ninja-build lld-19 binutils build-essential
-          # TODO: Remove once lld-19 becomes the default in Ubuntu repositories
-          update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
-          update-alternatives --config lld
-          update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-19 100
-          update-alternatives --config ld.lld
+                       ninja-build binutils build-essential
 
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,13 +172,13 @@ jobs:
     steps:
       - name: Install Linux platform dependencies
         run: |
-          apt update
-          apt install -y wget
+          apt-get update
+          apt-get install -y wget
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/llvm.asc
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | tee /etc/apt/sources.list.d/llvm.list
-          apt update
-          apt install -y \
-                       curl \
+          apt-get update
+          apt-get install -y \
+                       curl libssl-dev \
                        libpulse-dev libudev-dev libxcomposite-dev libxdamage-dev \
                        libxfixes-dev libxrandr-dev libxtst-dev \
                        ninja-build binutils build-essential

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,21 +172,21 @@ jobs:
     steps:
       - name: Install Linux platform dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y wget
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm.asc
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update
-          sudo apt-get install -y \
+          apt update
+          apt install -y wget
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/llvm.asc
+          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | tee /etc/apt/sources.list.d/llvm.list
+          apt update
+          apt install -y \
                        curl \
                        libpulse-dev libudev-dev libxcomposite-dev libxdamage-dev \
                        libxfixes-dev libxrandr-dev libxtst-dev \
                        ninja-build lld-19 binutils build-essential
           # TODO: Remove once lld-19 becomes the default in Ubuntu repositories
-          sudo update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
-          sudo update-alternatives --config lld
-          sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-19 100
-          sudo update-alternatives --config ld.lld
+          update-alternatives --install /usr/bin/lld lld /usr/bin/lld-19 100
+          update-alternatives --config lld
+          update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-19 100
+          update-alternatives --config ld.lld
 
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,18 +170,13 @@ jobs:
     # Pin glibc to 2.28 for better compatibility.
     container: debian:buster
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
-      - run: make rustup.targets only=linux
-
       - name: Install Linux platform dependencies
         run: |
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm.asc
           echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
           sudo apt-get install -y \
+                       curl \
                        libpulse-dev libudev-dev libxcomposite-dev libxdamage-dev \
                        libxfixes-dev libxrandr-dev libxtst-dev \
                        ninja-build lld-19 binutils build-essential
@@ -190,6 +185,13 @@ jobs:
           sudo update-alternatives --config lld
           sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-19 100
           sudo update-alternatives --config ld.lld
+
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - run: make rustup.targets only=linux
 
       - run: make cargo.build platform=linux debug=no
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           name: build-${{ matrix.platform }}
           path: ${{ matrix.platform }}/rust/
 
-  build-fultter:
+  build-flutter:
     needs: ["build-rust"]
     strategy:
       fail-fast: false

--- a/crates/libwebrtc-sys/build.rs
+++ b/crates/libwebrtc-sys/build.rs
@@ -212,7 +212,7 @@ fn main() -> anyhow::Result<()> {
 
     #[cfg(target_os = "linux")]
     {
-        if get_lld_version()?.0 < 19 {
+        if get_lld_version().0 < 19 {
             bail!(
                 "Compilation of the `libwebrtc-sys` crate requires `ldd` \
                  version 19 or higher, as the `libwebrtc` library it depends \
@@ -270,19 +270,18 @@ fn main() -> anyhow::Result<()> {
 
 #[cfg(target_os = "linux")]
 /// Returns version of `ld.lld` binary.
-fn get_lld_version() -> anyhow::Result<(u8, u8, u8)> {
-    let lld_result = Command::new("ld.lld").arg("--version").output()?;
-    let output = String::from_utf8(lld_result.stdout)?;
+fn get_lld_version() -> (u8, u8, u8) {
+    let lld_result = Command::new("ld.lld").arg("--version").output().unwrap();
+    let output = String::from_utf8(lld_result.stdout).unwrap();
 
-    Regex::new(r"LLD (\d+)\.(\d+)\.(\d+)")?
+    Regex::new(r"LLD (\d+)\.(\d+)\.(\d+)").unwrap()
         .captures(&output)
         .and_then(|caps| {
-            let major = caps.get(1)?.as_str().parse::<u8>().ok()?;
-            let minor = caps.get(2)?.as_str().parse::<u8>().ok()?;
-            let patch = caps.get(3)?.as_str().parse::<u8>().ok()?;
+            let major = caps.get(1).unwrap().as_str().parse::<u8>().ok().unwrap();
+            let minor = caps.get(2).unwrap().as_str().parse::<u8>().ok().unwrap();
+            let patch = caps.get(3).unwrap().as_str().parse::<u8>().ok().unwrap();
             Some((major, minor, patch))
-        })
-        .ok_or_else(|| anyhow!("Failed to parse `lld` version"))
+        }).unwrap()
 }
 
 /// Returns target architecture to build the library for.

--- a/crates/libwebrtc-sys/build.rs
+++ b/crates/libwebrtc-sys/build.rs
@@ -172,7 +172,7 @@ use walkdir::{DirEntry, WalkDir};
 /// [`libwebrtc-bin`]: https://github.com/instrumentisto/libwebrtc-bin
 static LIBWEBRTC_URL: &str = "\
     https://github.com/instrumentisto/libwebrtc-bin/releases/download\
-                                                            /134.0.6998.88";
+                                                            /132.0.6834.159";
 
 /// URL for downloading `openal-soft` source code.
 static OPENAL_URL: &str =
@@ -212,13 +212,13 @@ fn main() -> anyhow::Result<()> {
 
     #[cfg(target_os = "linux")]
     {
-        if get_lld_version()?.0 < 19 {
-            bail!(
-                "Compilation of the `libwebrtc-sys` crate requires `ldd` \
-                 version 19 or higher, as the `libwebrtc` library it depends \
-                 on is linked using CREL (introduced in version 19)",
-            );
-        }
+        // if get_lld_version()?.0 < 19 {
+        //     bail!(
+        //         "Compilation of the `libwebrtc-sys` crate requires `ldd` \
+        //          version 19 or higher, as the `libwebrtc` library it depends \
+        //          on is linked using CREL (introduced in version 19)",
+        //     );
+        // }
         println!("cargo:rustc-link-arg=-fuse-ld=lld");
         build
             .flag("-DWEBRTC_LINUX")

--- a/crates/libwebrtc-sys/build.rs
+++ b/crates/libwebrtc-sys/build.rs
@@ -294,19 +294,20 @@ fn get_target() -> anyhow::Result<String> {
 fn get_expected_libwebrtc_hash() -> anyhow::Result<&'static str> {
     Ok(match get_target()?.as_str() {
         "aarch64-unknown-linux-gnu" => {
-            "ace03f050a44b46f6a5040e3b762259b5825b9dbb2ccdd09b6755069a2b56a36"
+            "f1157f833b1cf65ff6d5105e07ceeb2fc030ff5579bd05651eb779249ae20d7f"
         }
         "x86_64-unknown-linux-gnu" => {
-            "5dfe171ee20a179f7c5ad59cce2602fccc6f2a37264336003ed56dfa7a539e53"
+            "daf132b62d511fcdfbafcc735c3aec2c6c173c2b1b704c1cb627b2d879f2dfee"
         }
         "aarch64-apple-darwin" => {
-            "8f69728cd602dcdd83d9693c29a9d89e54fd2b26aa3f32f9b8879d508743bb5b"
+            "f17865052d2c4e6987cb8ef6843242ecc2ad50c03a39d9dd03df0a91322d3f22"
         }
         "x86_64-apple-darwin" => {
-            "0f89249fa82c5d50aa0afa95b90e74479e86de9ca2b060e1be4bc585ac12d67c"
+            "dd54e994b0a750a221d1a8dea60fc3a57c34551141e688990c72ca49cf8339d0"
         }
         "x86_64-pc-windows-msvc" => {
-            "029886138771585b710b5da71812a87e49b126007abf4fc1980bbc248873d117"
+            "b426ddfeddd56b2a405aba08434c68d0a8b2c1bead31b5862407d741d4ea4b15"
+            "277ef4b36f885f983c097c6a181c886e584b34520894885d0f8ec70e9c4defae"
         }
         arch => return Err(anyhow::anyhow!("Unsupported target: {arch}")),
     })

--- a/crates/libwebrtc-sys/build.rs
+++ b/crates/libwebrtc-sys/build.rs
@@ -172,7 +172,7 @@ use walkdir::{DirEntry, WalkDir};
 /// [`libwebrtc-bin`]: https://github.com/instrumentisto/libwebrtc-bin
 static LIBWEBRTC_URL: &str = "\
     https://github.com/instrumentisto/libwebrtc-bin/releases/download\
-                                                            /132.0.6834.159";
+                                                            /134.0.6998.88";
 
 /// URL for downloading `openal-soft` source code.
 static OPENAL_URL: &str =
@@ -212,13 +212,13 @@ fn main() -> anyhow::Result<()> {
 
     #[cfg(target_os = "linux")]
     {
-        // if get_lld_version()?.0 < 19 {
-        //     bail!(
-        //         "Compilation of the `libwebrtc-sys` crate requires `ldd` \
-        //          version 19 or higher, as the `libwebrtc` library it depends \
-        //          on is linked using CREL (introduced in version 19)",
-        //     );
-        // }
+        if get_lld_version()?.0 < 19 {
+            bail!(
+                "Compilation of the `libwebrtc-sys` crate requires `ldd` \
+                 version 19 or higher, as the `libwebrtc` library it depends \
+                 on is linked using CREL (introduced in version 19)",
+            );
+        }
         println!("cargo:rustc-link-arg=-fuse-ld=lld");
         build
             .flag("-DWEBRTC_LINUX")
@@ -294,20 +294,19 @@ fn get_target() -> anyhow::Result<String> {
 fn get_expected_libwebrtc_hash() -> anyhow::Result<&'static str> {
     Ok(match get_target()?.as_str() {
         "aarch64-unknown-linux-gnu" => {
-            "f1157f833b1cf65ff6d5105e07ceeb2fc030ff5579bd05651eb779249ae20d7f"
+            "ace03f050a44b46f6a5040e3b762259b5825b9dbb2ccdd09b6755069a2b56a36"
         }
         "x86_64-unknown-linux-gnu" => {
-            "daf132b62d511fcdfbafcc735c3aec2c6c173c2b1b704c1cb627b2d879f2dfee"
+            "5dfe171ee20a179f7c5ad59cce2602fccc6f2a37264336003ed56dfa7a539e53"
         }
         "aarch64-apple-darwin" => {
-            "f17865052d2c4e6987cb8ef6843242ecc2ad50c03a39d9dd03df0a91322d3f22"
+            "8f69728cd602dcdd83d9693c29a9d89e54fd2b26aa3f32f9b8879d508743bb5b"
         }
         "x86_64-apple-darwin" => {
-            "dd54e994b0a750a221d1a8dea60fc3a57c34551141e688990c72ca49cf8339d0"
+            "0f89249fa82c5d50aa0afa95b90e74479e86de9ca2b060e1be4bc585ac12d67c"
         }
         "x86_64-pc-windows-msvc" => {
-            "b426ddfeddd56b2a405aba08434c68d0a8b2c1bead31b5862407d741d4ea4b15"
-            "277ef4b36f885f983c097c6a181c886e584b34520894885d0f8ec70e9c4defae"
+            "029886138771585b710b5da71812a87e49b126007abf4fc1980bbc248873d117"
         }
         arch => return Err(anyhow::anyhow!("Unsupported target: {arch}")),
     })


### PR DESCRIPTION
## Synopsis

We want glibc to be as-old-as-possible and pinned so github runner upgrade won't affect it.

[libwebrtc-bin](https://github.com/instrumentisto/libwebrtc-bin) since v134 requires lld-19 because of [crel](https://maskray.me/blog/2024-03-09-a-compact-relocation-format-for-elf) and lld-19 required libc6 >= 2.34 so we could use ubuntu:22.04 (libc v2.35) or debian:bookworm (libc v2.36). We've decided to stick with debian.



## Solution

Build linux artifacts in debian:bookworm + some additional CI refactoring.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
