### PR TITLE
Add getters for audio processing configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,12 @@ All user visible changes to this project will be documented in this file. This p
     - `MediaStreamTrack.setEchoCancellationEnabled` method enabling/disabling acoustic echo cancellation for local audio `MediaStreamTrack`.
     - `MediaStreamTrack.setAutoGainControlEnabled` method enabling/disabling auto gain control for local audio `MediaStreamTrack`.
     - `AudioConstraints.noiseSuppression`, `AudioConstraints.noiseSuppressionLevel`, `AudioConstraints.highPassFilter`, `AudioConstraints.echoCancellation` fields to control audio processing when creating local audio `MediaStreamTrack`.
-
-- Getters for audio processing settings for local audio `MediaStreamTrack`s on desktop: ([#199])
-    - `MediaStreamTrack.isNoiseSuppressionEnabled` method to check whether noise suppression is enabled for local audio `MediaStreamTrack`.
-    - `MediaStreamTrack.getNoiseSuppressionLevel` method to check noise suppression level on a local audio `MediaStreamTrack`.
-    - `MediaStreamTrack.isHighPassFilterEnabled` method to check whether high pass filter is enabled for local audio `MediaStreamTrack`.
-    - `MediaStreamTrack.isEchoCancellationEnabled` method to check whether acoustic echo cancellation is enabled for local audio `MediaStreamTrack`.
-    - `MediaStreamTrack.isAutoGainControlEnabled` method to check whether automatic gain control is enabled for local audio `MediaStreamTrack`.
+- Support for getting audio processing settings for local audio `MediaStreamTrack`s on desktop: ([#199])
+    - `MediaStreamTrack.isNoiseSuppressionEnabled` method checking whether noise suppression is enabled for local audio `MediaStreamTrack`.
+    - `MediaStreamTrack.getNoiseSuppressionLevel` method returning noise suppression level of local audio `MediaStreamTrack`.
+    - `MediaStreamTrack.isHighPassFilterEnabled` method checking whether high pass filter is enabled for local audio `MediaStreamTrack`.
+    - `MediaStreamTrack.isEchoCancellationEnabled` method checking whether acoustic echo cancellation is enabled for local audio `MediaStreamTrack`.
+    - `MediaStreamTrack.isAutoGainControlEnabled` method checking whether automatic gain control is enabled for local audio `MediaStreamTrack`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ All user visible changes to this project will be documented in this file. This p
     - `MediaStreamTrack.setAutoGainControlEnabled` method enabling/disabling auto gain control for local audio `MediaStreamTrack`.
     - `AudioConstraints.noiseSuppression`, `AudioConstraints.noiseSuppressionLevel`, `AudioConstraints.highPassFilter`, `AudioConstraints.echoCancellation` fields to control audio processing when creating local audio `MediaStreamTrack`.
 
+- Getters for audio processing settings for local audio `MediaStreamTrack`s on desktop: ([#199])
+    - `MediaStreamTrack.isNoiseSuppressionEnabled` method to check whether noise suppression is enabled for local audio `MediaStreamTrack`.
+    - `MediaStreamTrack.getNoiseSuppressionLevel` method to check noise suppression level on a local audio `MediaStreamTrack`.
+    - `MediaStreamTrack.isHighPassFilterEnabled` method to check whether high pass filter is enabled for local audio `MediaStreamTrack`.
+    - `MediaStreamTrack.isEchoCancellationEnabled` method to check whether acoustic echo cancellation is enabled for local audio `MediaStreamTrack`.
+    - `MediaStreamTrack.isAutoGainControlEnabled` method to check whether automatic gain control is enabled for local audio `MediaStreamTrack`.
+
 ### Changed
 
 - Upgraded [OpenAL] library to [1.24.3][openal-1.24.3] version. ([#193])
@@ -35,6 +42,7 @@ All user visible changes to this project will be documented in this file. This p
 [#195]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/195
 [#197]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/197
 [#198]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/198
+[#199]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/199
 [openal-1.24.3]: https://github.com/kcat/openal-soft/releases/tag/1.24.3
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -648,9 +648,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "hermit-abi"
@@ -923,7 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -1244,9 +1244,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -1397,9 +1397,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -1558,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1638,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/native/src/api/mod.rs
+++ b/crates/native/src/api/mod.rs
@@ -2087,7 +2087,7 @@ pub struct VideoConstraints {
     /// Identifier of the device generating the content of the
     /// [`MediaStreamTrack`].
     ///
-    /// First device will be chosen if an empty [`String`] is provided.
+    /// The first device will be chosen if an empty [`String`] is provided.
     pub device_id: Option<String>,
 
     /// Width in pixels.
@@ -2114,11 +2114,11 @@ pub struct AudioConstraints {
     /// First device will be chosen if an empty [`String`] is provided.
     pub device_id: Option<String>,
 
-    /// Audio processing configuration of the [`MediaStreamTrack`].
+    /// Audio processing configuration constraints of the [`MediaStreamTrack`].
     pub processing: AudioProcessingConstraints,
 }
 
-/// Audio processing configuration constraints.
+/// Constraints of an [`AudioProcessingConfig`].
 #[derive(Debug, Default)]
 pub struct AudioProcessingConstraints {
     /// Indicator whether the audio volume level should be automatically tuned
@@ -2141,7 +2141,7 @@ pub struct AudioProcessingConstraints {
     pub echo_cancellation: Option<bool>,
 }
 
-/// Audio processing configuration for some local audio [MediaStreamTrack].
+/// Audio processing configuration for some local audio [`MediaStreamTrack`].
 #[expect(clippy::struct_excessive_bools, reason = "that's ok")]
 #[derive(Debug)]
 pub struct AudioProcessingConfig {

--- a/crates/native/src/api/mod.rs
+++ b/crates/native/src/api/mod.rs
@@ -2115,12 +2115,12 @@ pub struct AudioConstraints {
     pub device_id: Option<String>,
 
     /// Audio processing configuration of the [`MediaStreamTrack`].
-    pub processing: AudioProcessingConfig,
+    pub processing: AudioProcessingConstraints,
 }
 
-/// Audio processing configuration.
+/// Audio processing configuration constraints.
 #[derive(Debug, Default)]
-pub struct AudioProcessingConfig {
+pub struct AudioProcessingConstraints {
     /// Indicator whether the audio volume level should be automatically tuned
     /// to maintain a steady overall volume level.
     pub auto_gain_control: Option<bool>,
@@ -2139,6 +2139,30 @@ pub struct AudioProcessingConfig {
     /// Indicator whether echo cancellation should be enabled to prevent
     /// feedback.
     pub echo_cancellation: Option<bool>,
+}
+
+/// Audio processing configuration for some local audio [MediaStreamTrack].
+#[expect(clippy::struct_excessive_bools, reason = "that's ok")]
+#[derive(Debug)]
+pub struct AudioProcessingConfig {
+    /// Indicator whether the audio volume level should be automatically tuned
+    /// to maintain a steady overall volume level.
+    pub auto_gain_control: bool,
+
+    /// Indicator whether a high-pass filter should be enabled to eliminate
+    /// low-frequency noise.
+    pub high_pass_filter: bool,
+
+    /// Indicator whether noise suppression should be enabled to reduce
+    /// background sounds.
+    pub noise_suppression: bool,
+
+    /// Level of aggressiveness for noise suppression.
+    pub noise_suppression_level: NoiseSuppressionLevel,
+
+    /// Indicator whether echo cancellation should be enabled to prevent
+    /// feedback.
+    pub echo_cancellation: bool,
 }
 
 /// [`AudioProcessingConfig`] noise suppression aggressiveness.
@@ -3000,12 +3024,12 @@ pub fn set_audio_level_observer_enabled(
     );
 }
 
-/// Applies the provided [`AudioProcessingConfig`] to specified local audio
+/// Applies the provided [`AudioProcessingConstraints`] to specified local audio
 /// track.
 #[expect(clippy::needless_pass_by_value, reason = "FFI")]
 pub fn update_audio_processing(
     track_id: String,
-    conf: AudioProcessingConfig,
+    conf: AudioProcessingConstraints,
 ) -> anyhow::Result<()> {
     WEBRTC.lock().unwrap().apply_audio_processing_config(track_id, &conf)
 }

--- a/crates/native/src/frb_generated.rs
+++ b/crates/native/src/frb_generated.rs
@@ -42,7 +42,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.9.0";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -192817599;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -40294053;
 
 // Section: executor
 
@@ -85,18 +85,18 @@ let api_init = <crate::api::RtpTransceiverInit>::sse_decode(&mut deserializer);d
                     })())
                 } })
 }
-fn wire__crate__api__audio_processing_config_default_impl(
+fn wire__crate__api__audio_processing_constraints_default_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
     data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "audio_processing_config_default", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "audio_processing_constraints_default", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
             let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
             let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             deserializer.end(); move |context|  {
                     transform_result_sse::<_, ()>((move ||  {
-                         let output_ok = Result::<_,()>::Ok(crate::api::AudioProcessingConfig::default())?;   Ok(output_ok)
+                         let output_ok = Result::<_,()>::Ok(crate::api::AudioProcessingConstraints::default())?;   Ok(output_ok)
                     })())
                 } })
 }
@@ -781,7 +781,7 @@ fn wire__crate__api__update_audio_processing_impl(
             let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
             let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_track_id = <String>::sse_decode(&mut deserializer);
-let api_conf = <crate::api::AudioProcessingConfig>::sse_decode(&mut deserializer);deserializer.end(); move |context|  {
+let api_conf = <crate::api::AudioProcessingConstraints>::sse_decode(&mut deserializer);deserializer.end(); move |context|  {
                     transform_result_sse::<_, flutter_rust_bridge::for_generated::anyhow::Error>((move ||  {
                          let output_ok = crate::api::update_audio_processing(api_track_id, api_conf)?;   Ok(output_ok)
                     })())
@@ -955,7 +955,7 @@ impl SseDecode for crate::api::AudioConstraints {
     ) -> Self {
         let mut var_deviceId = <Option<String>>::sse_decode(deserializer);
         let mut var_processing =
-            <crate::api::AudioProcessingConfig>::sse_decode(deserializer);
+            <crate::api::AudioProcessingConstraints>::sse_decode(deserializer);
         return crate::api::AudioConstraints {
             device_id: var_deviceId,
             processing: var_processing,
@@ -968,6 +968,27 @@ impl SseDecode for crate::api::AudioProcessingConfig {
     fn sse_decode(
         deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer,
     ) -> Self {
+        let mut var_autoGainControl = <bool>::sse_decode(deserializer);
+        let mut var_highPassFilter = <bool>::sse_decode(deserializer);
+        let mut var_noiseSuppression = <bool>::sse_decode(deserializer);
+        let mut var_noiseSuppressionLevel =
+            <crate::api::NoiseSuppressionLevel>::sse_decode(deserializer);
+        let mut var_echoCancellation = <bool>::sse_decode(deserializer);
+        return crate::api::AudioProcessingConfig {
+            auto_gain_control: var_autoGainControl,
+            high_pass_filter: var_highPassFilter,
+            noise_suppression: var_noiseSuppression,
+            noise_suppression_level: var_noiseSuppressionLevel,
+            echo_cancellation: var_echoCancellation,
+        };
+    }
+}
+
+impl SseDecode for crate::api::AudioProcessingConstraints {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(
+        deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer,
+    ) -> Self {
         let mut var_autoGainControl = <Option<bool>>::sse_decode(deserializer);
         let mut var_highPassFilter = <Option<bool>>::sse_decode(deserializer);
         let mut var_noiseSuppression = <Option<bool>>::sse_decode(deserializer);
@@ -975,7 +996,7 @@ impl SseDecode for crate::api::AudioProcessingConfig {
             crate::api::NoiseSuppressionLevel,
         >>::sse_decode(deserializer);
         let mut var_echoCancellation = <Option<bool>>::sse_decode(deserializer);
-        return crate::api::AudioProcessingConfig {
+        return crate::api::AudioProcessingConstraints {
             auto_gain_control: var_autoGainControl,
             high_pass_filter: var_highPassFilter,
             noise_suppression: var_noiseSuppression,
@@ -2808,7 +2829,7 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        3 => wire__crate__api__audio_processing_config_default_impl(
+        3 => wire__crate__api__audio_processing_constraints_default_impl(
             port,
             ptr,
             rust_vec_len,
@@ -3141,6 +3162,30 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::AudioProcessingConfig>
     for crate::api::AudioProcessingConfig
 {
     fn into_into_dart(self) -> crate::api::AudioProcessingConfig {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::AudioProcessingConstraints {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.auto_gain_control.into_into_dart().into_dart(),
+            self.high_pass_filter.into_into_dart().into_dart(),
+            self.noise_suppression.into_into_dart().into_dart(),
+            self.noise_suppression_level.into_into_dart().into_dart(),
+            self.echo_cancellation.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::AudioProcessingConstraints
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::AudioProcessingConstraints>
+    for crate::api::AudioProcessingConstraints
+{
+    fn into_into_dart(self) -> crate::api::AudioProcessingConstraints {
         self
     }
 }
@@ -4739,7 +4784,7 @@ impl SseEncode for crate::api::AudioConstraints {
         serializer: &mut flutter_rust_bridge::for_generated::SseSerializer,
     ) {
         <Option<String>>::sse_encode(self.device_id, serializer);
-        <crate::api::AudioProcessingConfig>::sse_encode(
+        <crate::api::AudioProcessingConstraints>::sse_encode(
             self.processing,
             serializer,
         );
@@ -4747,6 +4792,23 @@ impl SseEncode for crate::api::AudioConstraints {
 }
 
 impl SseEncode for crate::api::AudioProcessingConfig {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(
+        self,
+        serializer: &mut flutter_rust_bridge::for_generated::SseSerializer,
+    ) {
+        <bool>::sse_encode(self.auto_gain_control, serializer);
+        <bool>::sse_encode(self.high_pass_filter, serializer);
+        <bool>::sse_encode(self.noise_suppression, serializer);
+        <crate::api::NoiseSuppressionLevel>::sse_encode(
+            self.noise_suppression_level,
+            serializer,
+        );
+        <bool>::sse_encode(self.echo_cancellation, serializer);
+    }
+}
+
+impl SseEncode for crate::api::AudioProcessingConstraints {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(
         self,

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -603,7 +603,7 @@ impl Webrtc {
         let id = AudioTrackId::from(id);
         let Some(track) = self.audio_tracks.get_mut(&(id, TrackOrigin::Local))
         else {
-            // This means that the `AudioTrack` was already removed, so to omit 
+            // This means that the `AudioTrack` was already removed, so to omit
             // erroring something should be returned. It shouldn't really matter
             // what is returned, so default values are just okay.
             return Ok(api::AudioProcessingConfig {

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -603,9 +603,9 @@ impl Webrtc {
         let id = AudioTrackId::from(id);
         let Some(track) = self.audio_tracks.get_mut(&(id, TrackOrigin::Local))
         else {
-            // This means that track was already removed so we dont want to
-            // error and need to return something. This should not really matter
-            // what we return so lets stick to the default values.
+            // This means that the `AudioTrack` was already removed, so to omit 
+            // erroring something should be returned. It shouldn't really matter
+            // what is returned, so default values are just okay.
             return Ok(api::AudioProcessingConfig {
                 auto_gain_control: true,
                 high_pass_filter: true,

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -13,7 +13,9 @@ use sys::AudioProcessing;
 use xxhash::xxh3::xxh3_64;
 
 use crate::{
-    PeerConnection, VideoSink, VideoSinkId, Webrtc, api, devices,
+    PeerConnection, VideoSink, VideoSinkId, Webrtc, api,
+    api::NoiseSuppressionLevel,
+    devices,
     frb_generated::StreamSink,
     next_id,
     pc::{PeerConnectionId, RtpTransceiver},
@@ -562,7 +564,7 @@ impl Webrtc {
         }
     }
 
-    /// Applies the provided [`api::AudioProcessingConfig`] to the
+    /// Applies the provided [`api::AudioProcessingConstraints`] to the
     /// [`sys::AudioSourceInterface`] of the referred local [`AudioTrack`].
     ///
     /// # Errors
@@ -571,7 +573,7 @@ impl Webrtc {
     pub fn apply_audio_processing_config(
         &self,
         id: String,
-        conf: &api::AudioProcessingConfig,
+        conf: &api::AudioProcessingConstraints,
     ) -> anyhow::Result<()> {
         let id = AudioTrackId::from(id);
         let Some(track) = self.audio_tracks.get_mut(&(id, TrackOrigin::Local))
@@ -588,7 +590,7 @@ impl Webrtc {
         Ok(())
     }
 
-    /// Returns the [`api::AudioProcessingConfig`] of the
+    /// Returns the [`api::AudioProcessingConstraints`] of the
     /// [`sys::AudioSourceInterface`] of the referred local [`AudioTrack`].
     ///
     /// # Errors
@@ -601,7 +603,16 @@ impl Webrtc {
         let id = AudioTrackId::from(id);
         let Some(track) = self.audio_tracks.get_mut(&(id, TrackOrigin::Local))
         else {
-            return Ok(api::AudioProcessingConfig::default());
+            // This means that track was already removed so we dont want to
+            // error and need to return something. This should not really matter
+            // what we return so lets stick to the default values.
+            return Ok(api::AudioProcessingConfig {
+                auto_gain_control: true,
+                high_pass_filter: true,
+                noise_suppression: true,
+                noise_suppression_level: NoiseSuppressionLevel::VeryHigh,
+                echo_cancellation: true,
+            });
         };
 
         let MediaTrackSource::Local(src) = &track.source else {
@@ -609,18 +620,13 @@ impl Webrtc {
         };
 
         let mut conf = src.ap.config();
-        let auto_gain_control = conf.get_gain_controller_enabled();
-        let high_pass_filter = conf.get_high_pass_filter_enabled();
-        let noise_suppression = conf.get_noise_suppression_enabled();
-        let noise_suppression_level = conf.get_noise_suppression_level();
-        let echo_cancellation = conf.get_echo_cancellation_enabled();
 
         Ok(api::AudioProcessingConfig {
-            auto_gain_control: Some(auto_gain_control),
-            high_pass_filter: Some(high_pass_filter),
-            noise_suppression: Some(noise_suppression),
-            noise_suppression_level: Some(noise_suppression_level.into()),
-            echo_cancellation: Some(echo_cancellation),
+            auto_gain_control: conf.get_gain_controller_enabled(),
+            high_pass_filter: conf.get_high_pass_filter_enabled(),
+            noise_suppression: conf.get_noise_suppression_enabled(),
+            noise_suppression_level: conf.get_noise_suppression_level().into(),
+            echo_cancellation: conf.get_echo_cancellation_enabled(),
         })
     }
 }
@@ -1494,9 +1500,12 @@ impl AudioSource {
         }
     }
 
-    /// Applies the provided [`api::AudioProcessingConfig`] to the
+    /// Applies the provided [`api::AudioProcessingConstraints`] to the
     /// [`sys::AudioProcessing`] of this [`AudioSource`].
-    fn update_audio_processing(&self, new_conf: &api::AudioProcessingConfig) {
+    fn update_audio_processing(
+        &self,
+        new_conf: &api::AudioProcessingConstraints,
+    ) {
         let mut conf = self.ap.config();
         if let Some(aec) = new_conf.echo_cancellation {
             conf.set_echo_cancellation_enabled(aec);
@@ -1635,8 +1644,8 @@ impl AudioSourceAudioLevelHandler {
     }
 }
 
-impl From<&api::AudioProcessingConfig> for sys::AudioProcessingConfig {
-    fn from(caps: &api::AudioProcessingConfig) -> Self {
+impl From<&api::AudioProcessingConstraints> for sys::AudioProcessingConfig {
+    fn from(caps: &api::AudioProcessingConstraints) -> Self {
         let mut conf = Self::default();
 
         conf.set_high_pass_filter_enabled(

--- a/example/integration_test/webrtc_test.dart
+++ b/example/integration_test/webrtc_test.dart
@@ -3,8 +3,6 @@ import 'dart:io' show Platform;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:medea_flutter_webrtc/medea_flutter_webrtc.dart';
-import 'package:medea_flutter_webrtc/src/api/bridge/api.dart'
-    show getAudioProcessingConfig;
 import 'package:integration_test/integration_test.dart';
 
 void main() {
@@ -1440,6 +1438,13 @@ void main() {
   ) async {
     if (Platform.isAndroid || Platform.isIOS) {
       // Only supported on desktop.
+
+      var capsAudioOnly = DeviceConstraints();
+      capsAudioOnly.audio.mandatory = AudioConstraints();
+
+      var track = (await getUserMedia(capsAudioOnly))[0];
+      expect(track.isAudioProcessingAvailable(), isFalse);
+
       return;
     }
 
@@ -1449,15 +1454,14 @@ void main() {
       capsAudioOnly.audio.mandatory = AudioConstraints();
 
       var track = (await getUserMedia(capsAudioOnly))[0];
+      expect(track.isAudioProcessingAvailable(), isTrue);
 
-      var conf = await getAudioProcessingConfig(trackId: track.id());
-
-      expect(conf.noiseSuppression, isTrue);
-      expect(conf.highPassFilter, isTrue);
-      expect(conf.echoCancellation, isTrue);
-      expect(conf.autoGainControl, isTrue);
+      expect(await track.isNoiseSuppressionEnabled(), isTrue);
+      expect(track.isHighPassFilterEnabled(), isTrue);
+      expect(track.isEchoCancellationEnabled(), isTrue);
+      expect(track.isAutoGainControlEnabled(), isTrue);
       expect(
-        conf.noiseSuppressionLevel!.index,
+        (await track.getNoiseSuppressionLevel()).index,
         equals(NoiseSuppressionLevel.veryHigh.index),
       );
 
@@ -1477,14 +1481,12 @@ void main() {
 
       var track = (await getUserMedia(capsAudioOnly))[0];
 
-      var conf = await getAudioProcessingConfig(trackId: track.id());
-
-      expect(conf.noiseSuppression, isFalse);
-      expect(conf.highPassFilter, isFalse);
-      expect(conf.echoCancellation, isFalse);
-      expect(conf.autoGainControl, isFalse);
+      expect(await track.isNoiseSuppressionEnabled(), isFalse);
+      expect(await track.isHighPassFilterEnabled(), isFalse);
+      expect(await track.isEchoCancellationEnabled(), isFalse);
+      expect(await track.isAutoGainControlEnabled(), isFalse);
       expect(
-        conf.noiseSuppressionLevel!.index,
+        (await track.getNoiseSuppressionLevel()).index,
         equals(NoiseSuppressionLevel.low.index),
       );
 
@@ -1504,14 +1506,12 @@ void main() {
       await track.setAutoGainControlEnabled(false);
       await track.setNoiseSuppressionLevel(NoiseSuppressionLevel.low);
 
-      var conf = await getAudioProcessingConfig(trackId: track.id());
-
-      expect(conf.noiseSuppression, isFalse);
-      expect(conf.highPassFilter, isFalse);
-      expect(conf.echoCancellation, isFalse);
-      expect(conf.autoGainControl, isFalse);
+      expect(await track.isNoiseSuppressionEnabled(), isFalse);
+      expect(await track.isHighPassFilterEnabled(), isFalse);
+      expect(await track.isEchoCancellationEnabled(), isFalse);
+      expect(await track.isAutoGainControlEnabled(), isFalse);
       expect(
-        conf.noiseSuppressionLevel!.index,
+        (await track.getNoiseSuppressionLevel()).index,
         equals(NoiseSuppressionLevel.low.index),
       );
 
@@ -1537,14 +1537,12 @@ void main() {
       await track.setAutoGainControlEnabled(true);
       await track.setNoiseSuppressionLevel(NoiseSuppressionLevel.veryHigh);
 
-      var conf = await getAudioProcessingConfig(trackId: track.id());
-
-      expect(conf.noiseSuppression, isTrue);
-      expect(conf.highPassFilter, isTrue);
-      expect(conf.echoCancellation, isTrue);
-      expect(conf.autoGainControl, isTrue);
+      expect(await track.isNoiseSuppressionEnabled(), isTrue);
+      expect(await track.isHighPassFilterEnabled(), isTrue);
+      expect(await track.isEchoCancellationEnabled(), isTrue);
+      expect(await track.isAutoGainControlEnabled(), isTrue);
       expect(
-        conf.noiseSuppressionLevel!.index,
+        (await track.getNoiseSuppressionLevel()).index,
         equals(NoiseSuppressionLevel.veryHigh.index),
       );
 

--- a/example/integration_test/webrtc_test.dart
+++ b/example/integration_test/webrtc_test.dart
@@ -1444,8 +1444,25 @@ void main() {
 
       var track = (await getUserMedia(capsAudioOnly))[0];
       expect(track.isAudioProcessingAvailable(), isFalse);
+      expect(track.setNoiseSuppressionEnabled(true), throwsUnsupportedError);
+      expect(track.isNoiseSuppressionEnabled(), throwsUnsupportedError);
+
+      await track.stop();
 
       return;
+    }
+
+    {
+      // Does not work for video tracks
+      var capsVideoOnly = DeviceConstraints();
+      capsVideoOnly.video.mandatory = DeviceVideoConstraints();
+
+      var track = (await getUserMedia(capsVideoOnly))[0];
+      expect(track.isAudioProcessingAvailable(), isFalse);
+      expect(track.setNoiseSuppressionEnabled(true), throwsUnsupportedError);
+      expect(track.isNoiseSuppressionEnabled(), throwsUnsupportedError);
+
+      await track.stop();
     }
 
     {

--- a/example/integration_test/webrtc_test.dart
+++ b/example/integration_test/webrtc_test.dart
@@ -1457,9 +1457,9 @@ void main() {
       expect(track.isAudioProcessingAvailable(), isTrue);
 
       expect(await track.isNoiseSuppressionEnabled(), isTrue);
-      expect(track.isHighPassFilterEnabled(), isTrue);
-      expect(track.isEchoCancellationEnabled(), isTrue);
-      expect(track.isAutoGainControlEnabled(), isTrue);
+      expect(await track.isHighPassFilterEnabled(), isTrue);
+      expect(await track.isEchoCancellationEnabled(), isTrue);
+      expect(await track.isAutoGainControlEnabled(), isTrue);
       expect(
         (await track.getNoiseSuppressionLevel()).index,
         equals(NoiseSuppressionLevel.veryHigh.index),

--- a/lib/src/api/bridge/api.dart
+++ b/lib/src/api/bridge/api.dart
@@ -13,7 +13,7 @@ import 'renderer.dart';
 part 'api.freezed.dart';
 
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `TrackKind`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `hash`, `hash`, `hash`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `hash`, `hash`, `hash`
 
 /// Returns all [`VideoCodecInfo`]s of the supported video encoders.
 Future<List<VideoCodecInfo>> videoEncoders() =>
@@ -376,11 +376,11 @@ Future<void> setAudioLevelObserverEnabled({
   enabled: enabled,
 );
 
-/// Applies the provided [`AudioProcessingConfig`] to specified local audio
+/// Applies the provided [`AudioProcessingConstraints`] to specified local audio
 /// track.
 Future<void> updateAudioProcessing({
   required String trackId,
-  required AudioProcessingConfig conf,
+  required AudioProcessingConstraints conf,
 }) => RustLib.instance.api.crateApiUpdateAudioProcessing(
   trackId: trackId,
   conf: conf,
@@ -437,7 +437,7 @@ class AudioConstraints {
   final String? deviceId;
 
   /// Audio processing configuration of the [`MediaStreamTrack`].
-  final AudioProcessingConfig processing;
+  final AudioProcessingConstraints processing;
 
   const AudioConstraints({this.deviceId, required this.processing});
 
@@ -453,8 +453,56 @@ class AudioConstraints {
           processing == other.processing;
 }
 
-/// Audio processing configuration.
 class AudioProcessingConfig {
+  /// Indicator whether the audio volume level should be automatically tuned
+  /// to maintain a steady overall volume level.
+  final bool autoGainControl;
+
+  /// Indicator whether a high-pass filter should be enabled to eliminate
+  /// low-frequency noise.
+  final bool highPassFilter;
+
+  /// Indicator whether noise suppression should be enabled to reduce
+  /// background sounds.
+  final bool noiseSuppression;
+
+  /// Level of aggressiveness for noise suppression.
+  final NoiseSuppressionLevel noiseSuppressionLevel;
+
+  /// Indicator whether echo cancellation should be enabled to prevent
+  /// feedback.
+  final bool echoCancellation;
+
+  const AudioProcessingConfig({
+    required this.autoGainControl,
+    required this.highPassFilter,
+    required this.noiseSuppression,
+    required this.noiseSuppressionLevel,
+    required this.echoCancellation,
+  });
+
+  @override
+  int get hashCode =>
+      autoGainControl.hashCode ^
+      highPassFilter.hashCode ^
+      noiseSuppression.hashCode ^
+      noiseSuppressionLevel.hashCode ^
+      echoCancellation.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AudioProcessingConfig &&
+          runtimeType == other.runtimeType &&
+          autoGainControl == other.autoGainControl &&
+          highPassFilter == other.highPassFilter &&
+          noiseSuppression == other.noiseSuppression &&
+          noiseSuppressionLevel == other.noiseSuppressionLevel &&
+          echoCancellation == other.echoCancellation;
+}
+
+/// Audio processing configuration constraints.
+class AudioProcessingConstraints {
   /// Indicator whether the audio volume level should be automatically tuned
   /// to maintain a steady overall volume level.
   final bool? autoGainControl;
@@ -474,7 +522,7 @@ class AudioProcessingConfig {
   /// feedback.
   final bool? echoCancellation;
 
-  const AudioProcessingConfig({
+  const AudioProcessingConstraints({
     this.autoGainControl,
     this.highPassFilter,
     this.noiseSuppression,
@@ -482,8 +530,8 @@ class AudioProcessingConfig {
     this.echoCancellation,
   });
 
-  static Future<AudioProcessingConfig> default_() =>
-      RustLib.instance.api.crateApiAudioProcessingConfigDefault();
+  static Future<AudioProcessingConstraints> default_() =>
+      RustLib.instance.api.crateApiAudioProcessingConstraintsDefault();
 
   @override
   int get hashCode =>
@@ -496,7 +544,7 @@ class AudioProcessingConfig {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is AudioProcessingConfig &&
+      other is AudioProcessingConstraints &&
           runtimeType == other.runtimeType &&
           autoGainControl == other.autoGainControl &&
           highPassFilter == other.highPassFilter &&

--- a/lib/src/api/bridge/frb_generated.io.dart
+++ b/lib/src/api/bridge/frb_generated.io.dart
@@ -80,15 +80,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   AudioProcessingConfig dco_decode_audio_processing_config(dynamic raw);
 
   @protected
+  AudioProcessingConstraints dco_decode_audio_processing_constraints(
+    dynamic raw,
+  );
+
+  @protected
   bool dco_decode_bool(dynamic raw);
 
   @protected
   AudioConstraints dco_decode_box_autoadd_audio_constraints(dynamic raw);
 
   @protected
-  AudioProcessingConfig dco_decode_box_autoadd_audio_processing_config(
-    dynamic raw,
-  );
+  AudioProcessingConstraints
+  dco_decode_box_autoadd_audio_processing_constraints(dynamic raw);
 
   @protected
   bool dco_decode_box_autoadd_bool(dynamic raw);
@@ -515,6 +519,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  AudioProcessingConstraints sse_decode_audio_processing_constraints(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   bool sse_decode_bool(SseDeserializer deserializer);
 
   @protected
@@ -523,7 +532,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  AudioProcessingConfig sse_decode_box_autoadd_audio_processing_config(
+  AudioProcessingConstraints
+  sse_decode_box_autoadd_audio_processing_constraints(
     SseDeserializer deserializer,
   );
 
@@ -1056,6 +1066,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_audio_processing_constraints(
+    AudioProcessingConstraints self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_bool(bool self, SseSerializer serializer);
 
   @protected
@@ -1065,8 +1081,8 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_box_autoadd_audio_processing_config(
-    AudioProcessingConfig self,
+  void sse_encode_box_autoadd_audio_processing_constraints(
+    AudioProcessingConstraints self,
     SseSerializer serializer,
   );
 

--- a/lib/src/api/devices.dart
+++ b/lib/src/api/devices.dart
@@ -227,7 +227,7 @@ Future<List<NativeMediaStreamTrack>> _getUserMediaFFI(
       constraints.audio.mandatory != null || constraints.audio.optional != null
           ? ffi.AudioConstraints(
             deviceId: constraints.audio.mandatory?.deviceId,
-            processing: ffi.AudioProcessingConfig(
+            processing: ffi.AudioProcessingConstraints(
               autoGainControl:
                   constraints.audio.mandatory?.autoGainControl ??
                   constraints.audio.optional?.autoGainControl,
@@ -317,7 +317,7 @@ Future<List<NativeMediaStreamTrack>> _getDisplayMediaFFI(
       constraints.audio.mandatory != null || constraints.audio.optional != null
           ? ffi.AudioConstraints(
             deviceId: constraints.audio.mandatory?.deviceId,
-            processing: ffi.AudioProcessingConfig(),
+            processing: ffi.AudioProcessingConstraints(),
           )
           : null;
 

--- a/lib/src/platform/native/media_stream_track.dart
+++ b/lib/src/platform/native/media_stream_track.dart
@@ -352,67 +352,112 @@ class _NativeMediaStreamTrackFFI extends NativeMediaStreamTrack {
   @override
   Future<void> setAutoGainControlEnabled(bool enabled) async {
     if (!isAudioProcessingAvailable()) {
-      throw 'setAutoGainControlEnabled is unsupported, check with '
-          'isAudioProcessingAvailable beforehand';
+      super.setAutoGainControlEnabled(enabled);
     }
 
     await ffi.updateAudioProcessing(
       trackId: _id,
-      conf: ffi.AudioProcessingConfig(autoGainControl: enabled),
+      conf: ffi.AudioProcessingConstraints(autoGainControl: enabled),
     );
   }
 
   @override
   Future<void> setEchoCancellationEnabled(bool enabled) async {
     if (!isAudioProcessingAvailable()) {
-      throw 'setEchoCancellationEnabled is unsupported, check with '
-          'isAudioProcessingAvailable beforehand';
+      super.setEchoCancellationEnabled(enabled);
     }
 
     await ffi.updateAudioProcessing(
       trackId: _id,
-      conf: ffi.AudioProcessingConfig(echoCancellation: enabled),
+      conf: ffi.AudioProcessingConstraints(echoCancellation: enabled),
     );
   }
 
   @override
   Future<void> setHighPassFilterEnabled(bool enabled) async {
     if (!isAudioProcessingAvailable()) {
-      throw 'setHighPassFilterEnabled is unsupported, check with '
-          'isAudioProcessingAvailable beforehand';
+      super.setHighPassFilterEnabled(enabled);
     }
 
     await ffi.updateAudioProcessing(
       trackId: _id,
-      conf: ffi.AudioProcessingConfig(highPassFilter: enabled),
+      conf: ffi.AudioProcessingConstraints(highPassFilter: enabled),
     );
   }
 
   @override
   Future<void> setNoiseSuppressionEnabled(bool enabled) async {
     if (!isAudioProcessingAvailable()) {
-      throw 'setNoiseSuppressionEnabled is unsupported, check with '
-          'isAudioProcessingAvailable beforehand';
+      super.setNoiseSuppressionEnabled(enabled);
     }
 
     await ffi.updateAudioProcessing(
       trackId: _id,
-      conf: ffi.AudioProcessingConfig(noiseSuppression: enabled),
+      conf: ffi.AudioProcessingConstraints(noiseSuppression: enabled),
     );
   }
 
   @override
   Future<void> setNoiseSuppressionLevel(NoiseSuppressionLevel level) async {
     if (!isAudioProcessingAvailable()) {
-      throw 'setNoiseSuppressionLevel is unsupported, check with '
-          'isAudioProcessingAvailable beforehand';
+      super.setNoiseSuppressionLevel(level);
     }
 
     await ffi.updateAudioProcessing(
       trackId: _id,
-      conf: ffi.AudioProcessingConfig(
+      conf: ffi.AudioProcessingConstraints(
         noiseSuppressionLevel: ffi.NoiseSuppressionLevel.values[level.index],
       ),
     );
+  }
+
+  @override
+  Future<bool> isNoiseSuppressionEnabled() async {
+    if (!isAudioProcessingAvailable()) {
+      super.isNoiseSuppressionEnabled();
+    }
+
+    return (await ffi.getAudioProcessingConfig(trackId: _id)).noiseSuppression;
+  }
+
+  @override
+  Future<NoiseSuppressionLevel> getNoiseSuppressionLevel() async {
+    if (!isAudioProcessingAvailable()) {
+      super.getNoiseSuppressionLevel();
+    }
+
+    var level =
+        (await ffi.getAudioProcessingConfig(
+          trackId: _id,
+        )).noiseSuppressionLevel;
+
+    return NoiseSuppressionLevel.values[level.index];
+  }
+
+  @override
+  Future<bool> isHighPassFilterEnabled() async {
+    if (!isAudioProcessingAvailable()) {
+      super.isHighPassFilterEnabled();
+    }
+
+    return (await ffi.getAudioProcessingConfig(trackId: _id)).highPassFilter;
+  }
+
+  @override
+  Future<bool> isEchoCancellationEnabled() async {
+    if (!isAudioProcessingAvailable()) {
+      super.isEchoCancellationEnabled();
+    }
+
+    return (await ffi.getAudioProcessingConfig(trackId: _id)).echoCancellation;
+  }
+
+  @override
+  Future<bool> isAutoGainControlEnabled() async {
+    if (!isAudioProcessingAvailable()) {
+      super.isAutoGainControlEnabled();
+    }
+
+    return (await ffi.getAudioProcessingConfig(trackId: _id)).autoGainControl;
   }
 }

--- a/lib/src/platform/track.dart
+++ b/lib/src/platform/track.dart
@@ -118,12 +118,14 @@ abstract class MediaStreamTrack {
     throw _apNotSupported('setEchoCancellationEnabled');
   }
 
-  /// Enables/disables automatic gain control in the provided [MediaStreamTrack].
+  /// Enables/disables automatic gain control in the provided
+  /// [MediaStreamTrack].
   Future<void> setAutoGainControlEnabled(bool enabled) {
     throw _apNotSupported('setAutoGainControlEnabled');
   }
 
-  /// Indicates whether noise suppression is enabled in the provided [MediaStreamTrack].
+  /// Indicates whether noise suppression is enabled in the provided
+  /// [MediaStreamTrack].
   Future<bool> isNoiseSuppressionEnabled() {
     throw _apNotSupported('isNoiseSuppressionEnabled');
   }
@@ -132,17 +134,20 @@ abstract class MediaStreamTrack {
     throw _apNotSupported('getNoiseSuppressionLevel');
   }
 
-  /// Indicates whether high pass filter is enabled in the provided [MediaStreamTrack].
+  /// Indicates whether high pass filter is enabled in the provided
+  /// [MediaStreamTrack].
   Future<bool> isHighPassFilterEnabled() {
     throw _apNotSupported('isHighPassFilterEnabled');
   }
 
-  /// Indicates whether acoustic echo cancellation is enabled in the provided [MediaStreamTrack].
+  /// Indicates whether acoustic echo cancellation is enabled in the provided
+  /// [MediaStreamTrack].
   Future<bool> isEchoCancellationEnabled() {
     throw _apNotSupported('isEchoCancellationEnabled');
   }
 
-  /// Indicates whether automatic gain control is enabled in the provided [MediaStreamTrack].
+  /// Indicates whether automatic gain control is enabled in the provided
+  /// [MediaStreamTrack].
   Future<bool> isAutoGainControlEnabled() {
     throw _apNotSupported('isAutoGainControlEnabled');
   }
@@ -173,7 +178,7 @@ abstract class MediaStreamTrack {
   FutureOr<int?> height();
 }
 
-/// Creates an [UnsupportedError] to be thrown from audio processing methods.
+/// Creates an [UnsupportedError] to be thrown from audio processing [method]s.
 UnsupportedError _apNotSupported(String method) {
   return UnsupportedError(
     '$method is only support for local audio tracks '

--- a/lib/src/platform/track.dart
+++ b/lib/src/platform/track.dart
@@ -87,40 +87,64 @@ abstract class MediaStreamTrack {
   /// - [MediaStreamTrack.setHighPassFilterEnabled]
   /// - [MediaStreamTrack.setEchoCancellationEnabled]
   /// - [MediaStreamTrack.setAutoGainControlEnabled]
+  /// - [MediaStreamTrack.isNoiseSuppressionEnabled]
+  /// - [MediaStreamTrack.getNoiseSuppressionLevel]
+  /// - [MediaStreamTrack.isHighPassFilterEnabled]
+  /// - [MediaStreamTrack.isEchoCancellationEnabled]
+  /// - [MediaStreamTrack.isAutoGainControlEnabled]
   ///
   /// Only supported for local audio [MediaStreamTrack]s on desktop platforms.
   bool isAudioProcessingAvailable() {
     return false;
   }
 
+  /// Enables/disables noise suppression in the provided [MediaStreamTrack].
   Future<void> setNoiseSuppressionEnabled(bool enabled) {
-    throw 'setNoiseSuppressionEnabled is only support for local audio tracks '
-        'on desktop platforms. isAudioProcessingAvailable() should be called '
-        'before trying to call setNoiseSuppressionEnabled';
+    throw _apNotSupported('setNoiseSuppressionEnabled');
   }
 
+  /// Configures noise suppression level in the provided [MediaStreamTrack].
   Future<void> setNoiseSuppressionLevel(NoiseSuppressionLevel level) {
-    throw 'setNoiseSuppressionEnabled is only support for local audio tracks '
-        'on desktop platforms. isAudioProcessingAvailable() should be called '
-        'before trying to call setNoiseSuppressionEnabled';
+    throw _apNotSupported('setNoiseSuppressionLevel');
   }
 
+  /// Enables/disables high pass filter in the provided [MediaStreamTrack].
   Future<void> setHighPassFilterEnabled(bool enabled) {
-    throw 'setHighPassFilterEnabled is only support for local audio tracks '
-        'on desktop platforms. isAudioProcessingAvailable() should be called '
-        'before trying to call setHighPassFilterEnabled';
+    throw _apNotSupported('setHighPassFilterEnabled');
   }
 
+  /// Enables/disables echo cancellation in the provided [MediaStreamTrack].
   Future<void> setEchoCancellationEnabled(bool enabled) {
-    throw 'setEchoCancellationEnabled is only support for local audio tracks '
-        'on desktop platforms. isAudioProcessingAvailable() should be called '
-        'before trying to call setEchoCancellationEnabled';
+    throw _apNotSupported('setEchoCancellationEnabled');
   }
 
+  /// Enables/disables automatic gain control in the provided [MediaStreamTrack].
   Future<void> setAutoGainControlEnabled(bool enabled) {
-    throw 'setAutoGainControlEnabled is only support for local audio tracks '
-        'on desktop platforms. isAudioProcessingAvailable() should be called '
-        'before trying to call setAutoGainControlEnabled';
+    throw _apNotSupported('setAutoGainControlEnabled');
+  }
+
+  /// Indicates whether noise suppression is enabled in the provided [MediaStreamTrack].
+  Future<bool> isNoiseSuppressionEnabled() {
+    throw _apNotSupported('isNoiseSuppressionEnabled');
+  }
+
+  Future<NoiseSuppressionLevel> getNoiseSuppressionLevel() {
+    throw _apNotSupported('getNoiseSuppressionLevel');
+  }
+
+  /// Indicates whether high pass filter is enabled in the provided [MediaStreamTrack].
+  Future<bool> isHighPassFilterEnabled() {
+    throw _apNotSupported('isHighPassFilterEnabled');
+  }
+
+  /// Indicates whether acoustic echo cancellation is enabled in the provided [MediaStreamTrack].
+  Future<bool> isEchoCancellationEnabled() {
+    throw _apNotSupported('isEchoCancellationEnabled');
+  }
+
+  /// Indicates whether automatic gain control is enabled in the provided [MediaStreamTrack].
+  Future<bool> isAutoGainControlEnabled() {
+    throw _apNotSupported('isAutoGainControlEnabled');
   }
 
   /// Creates a new instance of [MediaStreamTrack], which will depend on the same
@@ -148,3 +172,14 @@ abstract class MediaStreamTrack {
   /// [height]: https://w3.org/TR/mediacapture-streams#dfn-height
   FutureOr<int?> height();
 }
+
+/// Creates an [UnsupportedError] to be thrown from audio processing methods.
+UnsupportedError _apNotSupported(String method) {
+  return UnsupportedError(
+    '$method is only support for local audio tracks '
+    'on desktop platforms. isAudioProcessingAvailable() should be called '
+    'before trying to call $method',
+  );
+}
+
+abstract class AudioProcessingConfig {}


### PR DESCRIPTION
## Synopsis

So since #197 we can cofigure audio processing for local audio tracks on desktop. Lets also add getters just in case (and i also want to make this testable in medea-jason).





## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
