### PR TITLE
Refactor pub fields in tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,6 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-## master
-
-## BC Breaks
-
-- Visibility of fields `id`, `source`, `track_events_tx` and `senders` from VideoTrack and AudioTrack is changed from public to private. ([#208])
-
-### Added
-
-- `VideoTrack.id()` method for getting `VideoTrackId`. ([#208])
-- `VideoTrack.source()` method for getting `VideoSource`. ([#208])
-- `VideoTrack.add_transceiver()`, `VideoTrack.remove_transceiver()` and `VideoTrack.remove_peer()` for managing senders of `VideoTrack`. ([#208])
-- `AudioTrack.id()` method for getting `AudioTrackId`. ([#208])
-- `AudioTrack.source()` method for getting `AudioSource`. ([#208])
-- `AudioTrack.add_transceiver()`, `AudioTrack.remove_transceiver()` and `AudioTrack.remove_peer()` for managing senders of `AudioTrack`. ([#208])
-
-[#208]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/208
-
-
-
-
 ## [0.15.0] · 2025-06-24
 [0.15.0]: https://github.com/instrumentisto/medea-flutter-webrtc/tree/0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## master
+
+## BC Breaks
+
+- Visibility of fields `id`, `source`, `track_events_tx` and `senders` from VideoTrack and AudioTrack is changed from public to private. ([#208])
+
+### Added
+
+- `VideoTrack.id()` method for getting `VideoTrackId`. ([#208])
+- `VideoTrack.source()` method for getting `VideoSource`. ([#208])
+- `VideoTrack.add_transceiver()`, `VideoTrack.remove_transceiver()` and `VideoTrack.remove_peer()` for managing senders of `VideoTrack`. ([#208])
+- `AudioTrack.id()` method for getting `AudioTrackId`. ([#208])
+- `AudioTrack.source()` method for getting `AudioSource`. ([#208])
+- `AudioTrack.add_transceiver()`, `AudioTrack.remove_transceiver()` and `AudioTrack.remove_peer()` for managing senders of `AudioTrack`. ([#208])
+
+[#208]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/208
+
+
+
+
 ## [0.15.0] · 2025-06-24
 [0.15.0]: https://github.com/instrumentisto/medea-flutter-webrtc/tree/0.15.0
 

--- a/crates/native/src/devices.rs
+++ b/crates/native/src/devices.rs
@@ -730,7 +730,7 @@ mod windows {
             audio_endpoint_enumerator
                 .RegisterEndpointNotificationCallback(&audio_endpoint_callback)
         }
-            .unwrap();
+        .unwrap();
 
         AUDIO_ENDPOINT_ENUMERATOR.swap(
             Box::into_raw(Box::new(audio_endpoint_enumerator)),

--- a/crates/native/src/devices.rs
+++ b/crates/native/src/devices.rs
@@ -327,10 +327,10 @@ impl Webrtc {
 
             for (_, delete_ai) in old_audio_ins {
                 for track in self.audio_tracks.iter() {
-                    if let MediaTrackSource::Local(s) = &track.source {
+                    if let MediaTrackSource::Local(s) = track.source() {
                         if s.device_id == delete_ai {
                             tracks_to_remove.push((
-                                track.id.clone().into(),
+                                track.id().into(),
                                 api::MediaType::Audio,
                             ));
                         }
@@ -343,10 +343,10 @@ impl Webrtc {
 
             for (_, delete_vi) in old_video_ins {
                 for track in self.video_tracks.iter() {
-                    if let MediaTrackSource::Local(s) = &track.source {
+                    if let MediaTrackSource::Local(s) = track.source() {
                         if s.device_id == delete_vi {
                             tracks_to_remove.push((
-                                track.id.clone().into(),
+                                track.id().into(),
                                 api::MediaType::Video,
                             ));
                         }
@@ -730,7 +730,7 @@ mod windows {
             audio_endpoint_enumerator
                 .RegisterEndpointNotificationCallback(&audio_endpoint_callback)
         }
-        .unwrap();
+            .unwrap();
 
         AUDIO_ENDPOINT_ENUMERATOR.swap(
             Box::into_raw(Box::new(audio_endpoint_enumerator)),

--- a/crates/native/src/pc.rs
+++ b/crates/native/src/pc.rs
@@ -41,7 +41,7 @@ impl Webrtc {
         obs.add(api::PeerConnectionEvent::PeerCreated {
             peer: RustOpaque::new(peer),
         })
-        .map_err(|e| anyhow!(e))?;
+            .map_err(|e| anyhow!(e))?;
 
         Ok(())
     }
@@ -1195,8 +1195,7 @@ impl sys::PeerConnectionEventsHandler for PeerConnectionObserver {
                         let track =
                             VideoTrack::wrap_remote(&transceiver, &peer);
                         let result = api::MediaStreamTrack::from(&track);
-                        video_tracks
-                            .insert((track.id.clone(), track_origin), track);
+                        video_tracks.insert((track.id(), track_origin), track);
 
                         result
                     }

--- a/crates/native/src/pc.rs
+++ b/crates/native/src/pc.rs
@@ -41,7 +41,7 @@ impl Webrtc {
         obs.add(api::PeerConnectionEvent::PeerCreated {
             peer: RustOpaque::new(peer),
         })
-            .map_err(|e| anyhow!(e))?;
+        .map_err(|e| anyhow!(e))?;
 
         Ok(())
     }
@@ -81,11 +81,11 @@ impl Webrtc {
     pub fn dispose_peer_connection(&self, this: &Arc<PeerConnection>) {
         // Remove all tracks from this `Peer`'s senders.
         for mut track in self.video_tracks.iter_mut() {
-            track.senders.remove(this);
+            track.remove_peer(this);
         }
 
         for mut track in self.audio_tracks.iter_mut() {
-            track.senders.remove(this);
+            track.remove_peer(this);
         }
 
         let peer = this.inner.lock().unwrap();
@@ -132,26 +132,12 @@ impl Webrtc {
         match transceiver.media_type() {
             sys::MediaType::MEDIA_TYPE_VIDEO => {
                 for mut track in self.video_tracks.iter_mut() {
-                    let mut delete = false;
-                    if let Some(trnscvrs) = track.senders.get_mut(peer) {
-                        trnscvrs.retain(|tr| tr != transceiver);
-                        delete = trnscvrs.is_empty();
-                    }
-                    if delete {
-                        track.senders.remove(peer);
-                    }
+                    track.remove_transceiver(peer, transceiver);
                 }
             }
             sys::MediaType::MEDIA_TYPE_AUDIO => {
                 for mut track in self.audio_tracks.iter_mut() {
-                    let mut delete = false;
-                    if let Some(trnscvrs) = track.senders.get_mut(peer) {
-                        trnscvrs.retain(|tr| tr != transceiver);
-                        delete = trnscvrs.is_empty();
-                    }
-                    if delete {
-                        track.senders.remove(peer);
-                    }
+                    track.remove_transceiver(peer, transceiver);
                 }
             }
             _ => unreachable!(),
@@ -169,12 +155,10 @@ impl Webrtc {
                             anyhow!("Cannot find track with ID `{track_id}`")
                         })?;
 
-                    track
-                        .value_mut()
-                        .senders
-                        .entry(Arc::clone(peer))
-                        .or_default()
-                        .insert(Arc::clone(transceiver));
+                    track.add_transceiver(
+                        Arc::clone(peer),
+                        Arc::clone(transceiver),
+                    );
 
                     sender.replace_video_track(Some(track.as_ref()))
                 }
@@ -187,12 +171,10 @@ impl Webrtc {
                             anyhow!("Cannot find track with ID `{track_id}`")
                         })?;
 
-                    track
-                        .value_mut()
-                        .senders
-                        .entry(Arc::clone(peer))
-                        .or_default()
-                        .insert(Arc::clone(transceiver));
+                    track.add_transceiver(
+                        Arc::clone(peer),
+                        Arc::clone(transceiver),
+                    );
 
                     sender.replace_audio_track(Some(track.as_ref()))
                 }

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -1047,7 +1047,7 @@ impl VideoTrack {
         self.id.clone()
     }
 
-    /// Returns [`VideoSource`] that is used by this [`VideoTrack`].
+    /// Returns the [`VideoSource`] that is used by this [`VideoTrack`].
     #[must_use]
     pub const fn source(&self) -> &MediaTrackSource<VideoSource> {
         &self.source
@@ -1188,7 +1188,7 @@ impl VideoTrack {
         }
     }
 
-    /// Adds transceiver to senders of this [`VideoTrack`].
+    /// Adds the provided [`RtpTransceiver`] to senders of this [`VideoTrack`].
     pub fn add_transceiver(
         &mut self,
         peer: Arc<PeerConnection>,
@@ -1197,7 +1197,8 @@ impl VideoTrack {
         self.senders.entry(peer).or_default().insert(transceiver);
     }
 
-    /// Removes transceiver from senders of this [`VideoTrack`].
+    /// Removes the specified [`RtpTransceiver`] from senders of this
+    /// [`VideoTrack`].
     pub fn remove_transceiver(
         &mut self,
         peer: &Arc<PeerConnection>,
@@ -1214,7 +1215,8 @@ impl VideoTrack {
         self.senders.remove(peer);
     }
 
-    /// Removes peer and its transceivers from senders of this [`VideoTrack`].
+    /// Removes the specified [`PeerConnection`] and its [`RtpTransceiver`]s
+    /// from senders of this [`VideoTrack`].
     pub fn remove_peer(&mut self, peer: &Arc<PeerConnection>) {
         self.senders.remove(peer);
     }
@@ -1286,7 +1288,7 @@ impl AudioTrack {
         self.id.clone()
     }
 
-    /// Returns [`AudioSource`] that is used by this [`AudioTrack`].
+    /// Returns the [`AudioSource`] that is used by this [`AudioTrack`].
     #[must_use]
     pub const fn source(&self) -> &MediaTrackSource<AudioSource> {
         &self.source
@@ -1401,7 +1403,7 @@ impl AudioTrack {
         }
     }
 
-    /// Adds transceiver to senders of this [`VideoTrack`].
+    /// Adds the provided [`RtpTransceiver`] to senders of this [`VideoTrack`].
     pub fn add_transceiver(
         &mut self,
         peer: Arc<PeerConnection>,
@@ -1410,7 +1412,8 @@ impl AudioTrack {
         self.senders.entry(peer).or_default().insert(transceiver);
     }
 
-    /// Removes transceiver from senders of this [`VideoTrack`].
+    /// Removes the specified [`RtpTransceiver`] from senders of this
+    /// [`VideoTrack`].
     pub fn remove_transceiver(
         &mut self,
         peer: &Arc<PeerConnection>,
@@ -1427,7 +1430,8 @@ impl AudioTrack {
         self.senders.remove(peer);
     }
 
-    /// Removes peer and its transceivers from senders of this [`VideoTrack`].
+    /// Removes the specified [`PeerConnection`] and its [`RtpTransceiver`]s
+    /// from senders of this [`VideoTrack`].
     pub fn remove_peer(&mut self, peer: &Arc<PeerConnection>) {
         self.senders.remove(peer);
     }

--- a/crates/native/src/user_media.rs
+++ b/crates/native/src/user_media.rs
@@ -1259,7 +1259,7 @@ pub struct AudioTrack {
     #[as_ref]
     inner: sys::AudioTrackInterface,
 
-    /// [`sys::AudioSourceInterface`] that is used by this [`AudioTrack`].
+    /// [`AudioSource`] that is used by this [`AudioTrack`].
     source: MediaTrackSource<AudioSource>,
 
     /// [`api::TrackKind::kAudio`].
@@ -1286,7 +1286,7 @@ impl AudioTrack {
         self.id.clone()
     }
 
-    /// Returns [`sys::AudioSourceInterface`] that is used by this [`AudioTrack`].
+    /// Returns [`AudioSource`] that is used by this [`AudioTrack`].
     #[must_use]
     pub const fn source(&self) -> &MediaTrackSource<AudioSource> {
         &self.source


### PR DESCRIPTION
Resolves #207 
Part of #206 

## Synopsis

Fields `id`, `source`, `track_events_tx` and `senders` are public. It's an antipattern and makes refactoring difficult.

## Solution

Expose getters for `id` and `source` and add methods for managing `senders` to tracks.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
