### PR TITLE
Lock `flutter_rust_bridge_codegen` dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,10 +283,12 @@ endif
 
 cargo.gen:
 ifeq ($(shell which flutter_rust_bridge_codegen),)
-	cargo install flutter_rust_bridge_codegen --vers=$(FLUTTER_RUST_BRIDGE_VER)
+	cargo install flutter_rust_bridge_codegen --locked \
+	                                          --vers=$(FLUTTER_RUST_BRIDGE_VER)
 else
 ifneq ($(strip $(shell flutter_rust_bridge_codegen --version | cut -d ' ' -f2)),$(FLUTTER_RUST_BRIDGE_VER))
 	cargo install flutter_rust_bridge_codegen --force \
+	                                          --locked \
 	                                          --vers=$(FLUTTER_RUST_BRIDGE_VER)
 endif
 endif


### PR DESCRIPTION
Resolves #234 

## Synopsis

Upgrades of `flutter_rust_bridge_codegen` dependencies can break its installation during `make cargo.gen` even if exact version number is set in `Cargo.toml`.

## Solution

`--locked` option can be passed to `cargo install` to use `Cargo.lock` of `flutter_rust_bridge_codegen` during installation of its dependencies.

## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
    - [ ] Has assignee
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
