### PR TITLE
Remove references to private elements from track documentation

### DIFF
--- a/crates/native/src/media/track.rs
+++ b/crates/native/src/media/track.rs
@@ -207,7 +207,7 @@ impl<T> Track<T> {
         }
     }
 
-    /// Sets the provided [`StreamSink`] for this [`Track`] to use for
+    /// Sets the provided `StreamSink` for this [`Track`] to use for
     /// [`api::TrackEvent`]s emitting.
     pub fn set_track_events_tx(&mut self, sink: StreamSink<api::TrackEvent>) {
         drop(self.events_tx.replace(sink));
@@ -264,7 +264,7 @@ impl<T> Track<T> {
     }
 }
 
-/// Representation of a [`kind::Video`] [`Track`] interface.
+/// Representation of a video [`Track`] interface.
 pub type VideoTrack = Track<kind::Video>;
 
 impl VideoTrack {
@@ -466,7 +466,7 @@ impl sys::OnFrameCallback for VideoFormatSink {
     }
 }
 
-/// Representation of a [`kind::Audio`] [`Track`] interface.
+/// Representation of an audio [`Track`] interface.
 pub type AudioTrack = Track<kind::Audio>;
 
 impl AudioTrack {


### PR DESCRIPTION
## Synopsis

`rustdoc` CI checks are failing because there are references to private `kind` module and `StreamSink` struct.

## Solution

I think these references can be removed from documentation because there are no way for end user to create `kind::Audio`, `kind::Video` or `StreamSink`.

## Checklist

- Created PR:
    - [ ] In [draft mode][l:1]
    - [ ] Name contains issue reference
    - [ ] Has type and `k::` labels applied
    - [ ] Has assignee
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
