### PR TITLE
Fix `pr` CI job conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,19 @@ jobs:
   ################
 
   pr:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request'
+         && needs.build-rust.result == 'success'
+         && needs.build-rust-linux.result == 'success'
+         && needs.build-flutter.result == 'success'
+         && needs.clippy.result == 'success'
+         && needs.codegen.result == 'success'
+         && needs.dartanalyze.result == 'success'
+         && needs.dartfmt.result == 'success'
+         && needs.ktfmt.result == 'success'
+         && needs.rustdoc.result == 'success'
+         && needs.rustfmt.result == 'success'
+         && needs.swiftformat.result == 'success'
+         && needs.test-flutter.result == 'success' }}
     needs:
       - build-rust
       - build-rust-linux


### PR DESCRIPTION
## Synopsis

`pr` CI job succeeds even if one of its `needs` job fails.




## Solution

Consider `needs` job's condition in `if` on `pr` CI job.

For more context see: https://github.com/orgs/community/discussions/25970#discussioncomment-6515748




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [ ] Documentation is updated (if required)
    - [ ] Tests are updated (if required)
    - [ ] Changes conform [code style][l:2]
    - [ ] [CHANGELOG entry][l:3] is added (if required)
    - [ ] FCM (final commit message) is posted or updated
    - [ ] [Draft mode][l:1] is removed
- [ ] [Review][l:4] is completed and changes are approved
    - [ ] FCM (final commit message) is approved
- Before merge:
    - [ ] Milestone is set
    - [ ] PR's name and description are correct and up-to-date
    - [ ] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
