### PR TITLE
Fix WebVideoRenderer.onResize and dimensions calculation race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,7 @@ All user visible changes to this project will be documented in this file. This p
 
 ### Fixed
 
-- [Android]:
-  - `WebVideoRenderer` reporting 0x0 dimensions. ([#252])
+- `WebVideoRenderer` reporting 0x0 dimensions. ([#252])
 
 [#244]: https://github.com/instrumentisto/medea-flutter-webrtc/issues/244
 [#245]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/245

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,16 @@ All user visible changes to this project will be documented in this file. This p
 
 - Upgraded [libwebrtc] to [139.0.7258.138] version. ([#248], [todo])
 
+### Fixed
+
+- [Android]:
+  - `WebVideoRenderer` reporting 0x0 dimensions. ([#252])
+
 [#244]: https://github.com/instrumentisto/medea-flutter-webrtc/issues/244
 [#245]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/245
 [#248]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/248
 [#250]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/250
+[#252]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/252
 [139.0.7258.138]: https://github.com/instrumentisto/libwebrtc-bin/releases/tag/139.0.7258.138
 
 

--- a/lib/src/platform/web/video_renderer.dart
+++ b/lib/src/platform/web/video_renderer.dart
@@ -111,12 +111,12 @@ class WebVideoRenderer extends VideoRenderer {
 
   String get _elementIdForVideo => 'video_RTCVideoRenderer-$textureId';
 
-  void _updateAllValues() {
-    final element = findHtmlView();
+  void _updateAllValues(web.HTMLVideoElement fallback) {
+    final element = findHtmlView() ?? fallback;
     value = value.copyWith(
       rotation: 0,
-      width: element?.videoWidth.toDouble() ?? 0.0,
-      height: element?.videoHeight.toDouble() ?? 0.0,
+      width: element.videoWidth.toDouble(),
+      height: element.videoHeight.toDouble(),
       renderVideo: renderVideo,
     );
   }
@@ -216,14 +216,14 @@ class WebVideoRenderer extends VideoRenderer {
 
       _subscriptions.add(
         element.onCanPlay.listen((dynamic _) {
-          _updateAllValues();
+          _updateAllValues(element);
           onCanPlay?.call();
         }),
       );
 
       _subscriptions.add(
         element.onResize.listen((dynamic _) {
-          _updateAllValues();
+          _updateAllValues(element);
           onResize?.call();
         }),
       );


### PR DESCRIPTION
## Synopsis

`WebVideoRenderer.onResize` might report 0x0 video element dimesions. 



## Solution

This was already fixed in upstream https://github.com/flutter-webrtc/flutter-webrtc/pull/1805, just move this changes here




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
