### PR TITLE
Refactor Android audio devices management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
+          components: rustfmt
 
       - name: Install `linux` platform dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All user visible changes to this project will be documented in this file. This p
 ### Added
 
 - Support for system audio capturing on [Windows] via `getDisplayMedia()`. ([#245], [#244])
-- Capture audio focus when in call on [Android]. ([#255])
+- Capturing audio focus when in call on [Android]. ([#255])
 
 ### Changed
 
@@ -29,7 +29,7 @@ All user visible changes to this project will be documented in this file. This p
 ### Fixed
 
 - `WebVideoRenderer` reporting 0x0 dimensions. ([#252])
-- `RtpSender` being disposed before `RtpTransceiver` causing `replaceTrack` calls to do nothing on [Android]. ([#255])
+- `RtpSender` being disposed before `RtpTransceiver` causing `replaceTrack()` calls doing nothing on [Android]. ([#255])
 - `OnDeviceChangeCallback` not being called on wired headset connect/disconnect on [Android]. ([#255])
 
 [#244]: https://github.com/instrumentisto/medea-flutter-webrtc/issues/244

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All user visible changes to this project will be documented in this file. This p
 ### Added
 
 - Support for system audio capturing on [Windows] via `getDisplayMedia()`. ([#245], [#244])
+- Capture audio focus when in call on [Android]. ([#255])
 
 ### Changed
 
@@ -28,6 +29,8 @@ All user visible changes to this project will be documented in this file. This p
 ### Fixed
 
 - `WebVideoRenderer` reporting 0x0 dimensions. ([#252])
+- `RtpSender` being disposed before `RtpTransceiver` causing `replaceTrack` calls to do nothing on [Android]. ([#255])
+- `OnDeviceChangeCallback` not being called on wired headset connect/disconnect on [Android]. ([#255])
 
 [#244]: https://github.com/instrumentisto/medea-flutter-webrtc/issues/244
 [#245]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/245
@@ -35,6 +38,7 @@ All user visible changes to this project will be documented in this file. This p
 [#250]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/250
 [#252]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/252
 [#254]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/254
+[#255]: https://github.com/instrumentisto/medea-flutter-webrtc/pull/255
 [140.0.7339.127]: https://github.com/instrumentisto/libwebrtc-bin/releases/tag/140.0.7339.127
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -41,15 +41,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arbitrary"
@@ -80,9 +80,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -90,7 +90,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.37"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -189,18 +189,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f81de88da10862f22b5b3a60f18f6f42bbe7cb8faa24845dd7b1e4e22190e77"
+checksum = "4e9c4fe7f2f5dc5c62871a1b43992d197da6fa1394656a94276ac2894a90a6fe"
 dependencies = [
  "cc",
  "cxx-build",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edd58bf75c3fdfc80d79806403af626570662f7b6cc782a7fabe156166bd6d6"
+checksum = "b5cf2909d37d80633ddd208676fc27c2608a7f035fff69c882421168038b26dd"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd46bf2b541a4e0c2d5abba76607379ee05d68e714868e3cb406dc8d591ce2d2"
+checksum = "077f5ee3d3bfd8d27f83208fdaa96ddd50af7f096c77077cc4b94da10bfacefd"
 dependencies = [
  "clap",
  "codespan-reporting",
@@ -341,15 +341,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c79b68f6a3a8f809d39b38ae8af61305a6113819b19b262643b9c21353b92d9"
+checksum = "b0108748615125b9f2e915dfafdffcbdabbca9b15102834f6d7e9a768f2f2864"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.185"
+version = "1.0.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862b7fdb048ff9ef0779a0d0a03affd09746c4c875543746b640756be9cff2af"
+checksum = "e6e896681ef9b8dc462cfa6961d61909704bde0984b30bcb4082fe102b478890"
 dependencies = [
  "indexmap",
  "proc-macro2",
@@ -383,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "delegate-attr"
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
@@ -489,7 +489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -512,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "flate2"
@@ -724,9 +724,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1093,9 +1093,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libpulse-binding"
@@ -1265,9 +1265,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mime"
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1498,9 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -1598,14 +1598,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1625,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1661,7 +1661,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1711,18 +1711,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1893,15 +1893,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -1924,9 +1924,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1980,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -2073,9 +2073,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
@@ -2176,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2189,9 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -2203,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.53"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2216,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2226,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2239,18 +2239,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2278,7 +2278,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2289,31 +2289,30 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
+checksum = "49e6c4a1f363c8210c6f77ba24f645c61c6fb941eccf013da691f7e09515b8ac"
 dependencies = [
  "windows-collections",
  "windows-core",
  "windows-future",
- "windows-link 0.2.0",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90dd7a7b86859ec4cdf864658b311545ef19dbcf17a672b52ab7cefe80c336f"
+checksum = "123e712f464a8a60ce1a13f4c446d2d43ab06464cb5842ff68f5c71b6fb7852e"
 dependencies = [
  "windows-core",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -2324,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "windows-future"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2194dee901458cb79e1148a4e9aac2b164cc95fa431891e7b296ff0b2f1d8a6"
+checksum = "68f3db6b24b120200d649cd4811b4947188ed3a8d2626f7075146c5d178a9a4a"
 dependencies = [
  "windows-core",
  "windows-link 0.2.0",
@@ -2335,9 +2334,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2346,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2448,14 +2447,14 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
  "windows-link 0.2.0",
 ]
@@ -2478,11 +2477,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link 0.2.0",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -2612,9 +2611,9 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xattr"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
@@ -2673,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 24
         consumerProguardFiles("proguard-rules.pro")
     }
 

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MedeaFlutterWebrtcPlugin.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/MedeaFlutterWebrtcPlugin.kt
@@ -5,6 +5,7 @@ import com.instrumentisto.medea_flutter_webrtc.controller.ControllerRegistry
 import com.instrumentisto.medea_flutter_webrtc.controller.MediaDevicesController
 import com.instrumentisto.medea_flutter_webrtc.controller.PeerConnectionFactoryController
 import com.instrumentisto.medea_flutter_webrtc.controller.VideoRendererFactoryController
+import com.instrumentisto.medea_flutter_webrtc.media.MediaDevices
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -51,9 +52,11 @@ class MedeaFlutterWebrtcPlugin : FlutterPlugin, ActivityAware {
 
     activityPluginBinding = registrar
     permissions = Permissions(activityPluginBinding!!.activity)
+    val media = MediaDevices(state!!, permissions!!)
     activityPluginBinding!!.addRequestPermissionsResultListener(permissions!!)
-    mediaDevices = MediaDevicesController(messenger!!, state!!, permissions!!)
-    peerConnectionFactory = PeerConnectionFactoryController(messenger!!, state!!, permissions!!)
+    mediaDevices = MediaDevicesController(messenger!!, media, state!!, permissions!!)
+    peerConnectionFactory =
+        PeerConnectionFactoryController(messenger!!, state!!, media, permissions!!)
     videoRendererFactory = VideoRendererFactoryController(messenger!!, textureRegistry!!)
   }
 

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/MediaDevicesController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/MediaDevicesController.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
  * Controller of [MediaDevices] functional.
  *
  * @property messenger Messenger used for creating new [MethodChannel]s.
+ * @property mediaDevices [MediaDevices] to perform [MethodCall]s on.
  * @param state State used for creating new [MediaStreamTrackProxy]s.
  */
 class MediaDevicesController(

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/MediaDevicesController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/MediaDevicesController.kt
@@ -1,10 +1,10 @@
 package com.instrumentisto.medea_flutter_webrtc.controller
 
 import com.instrumentisto.medea_flutter_webrtc.ForegroundCallService
-import com.instrumentisto.medea_flutter_webrtc.MediaDevices
 import com.instrumentisto.medea_flutter_webrtc.Permissions
 import com.instrumentisto.medea_flutter_webrtc.State
 import com.instrumentisto.medea_flutter_webrtc.exception.GetUserMediaException
+import com.instrumentisto.medea_flutter_webrtc.media.MediaDevices
 import com.instrumentisto.medea_flutter_webrtc.model.Constraints
 import com.instrumentisto.medea_flutter_webrtc.proxy.MediaStreamTrackProxy
 import com.instrumentisto.medea_flutter_webrtc.proxy.PeerConnectionProxy
@@ -27,14 +27,12 @@ import kotlinx.coroutines.launch
  */
 class MediaDevicesController(
     private val messenger: BinaryMessenger,
+    private val mediaDevices: MediaDevices,
     state: State,
     permissions: Permissions
 ) : EventChannel.StreamHandler, Controller {
   /** [CoroutineScope] for this [MediaDevicesController] */
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-
-  /** Underlying [MediaDevices] to perform [MethodCall]s on. */
-  private val mediaDevices = MediaDevices(state, permissions)
 
   /** Channel listened for [MethodCall]s. */
   private val chan = MethodChannel(messenger, ChannelNameGenerator.name("MediaDevices", 0))
@@ -123,6 +121,7 @@ class MediaDevicesController(
           }
         }
       }
+      else -> result.notImplemented()
     }
   }
 

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/MediaStreamTrackController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/MediaStreamTrackController.kt
@@ -88,6 +88,7 @@ class MediaStreamTrackController(
         disposeInternal(false)
         result.success(null)
       }
+      else -> result.notImplemented()
     }
   }
 

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/PeerConnectionController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/PeerConnectionController.kt
@@ -196,6 +196,7 @@ class PeerConnectionController(
         disposeInternal(false)
         result.success(null)
       }
+      else -> result.notImplemented()
     }
   }
 

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/PeerConnectionFactoryController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/PeerConnectionFactoryController.kt
@@ -2,6 +2,7 @@ package com.instrumentisto.medea_flutter_webrtc.controller
 
 import com.instrumentisto.medea_flutter_webrtc.Permissions
 import com.instrumentisto.medea_flutter_webrtc.State
+import com.instrumentisto.medea_flutter_webrtc.media.MediaDevices
 import com.instrumentisto.medea_flutter_webrtc.model.IceServer
 import com.instrumentisto.medea_flutter_webrtc.model.IceTransportType
 import com.instrumentisto.medea_flutter_webrtc.model.PeerConnectionConfiguration
@@ -30,13 +31,15 @@ import org.webrtc.MediaStreamTrack
 class PeerConnectionFactoryController(
     private val messenger: BinaryMessenger,
     private val state: State,
+    mediaDevices: MediaDevices,
     permissions: Permissions
 ) : Controller {
   /** [CoroutineScope] for this [PeerConnectionFactoryController] */
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
   /** Factory creating new [PeerConnectionController]s. */
-  private val factory: PeerConnectionFactoryProxy = PeerConnectionFactoryProxy(state, permissions)
+  private val factory: PeerConnectionFactoryProxy =
+      PeerConnectionFactoryProxy(state, mediaDevices, permissions)
 
   /** Channel listened for the [MethodCall]s. */
   private val chan = MethodChannel(messenger, ChannelNameGenerator.name("PeerConnectionFactory", 0))
@@ -119,6 +122,7 @@ class PeerConnectionFactoryController(
         dispose()
         result.success(null)
       }
+      else -> result.notImplemented()
     }
   }
 

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/PeerConnectionFactoryController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/PeerConnectionFactoryController.kt
@@ -26,7 +26,8 @@ import org.webrtc.MediaStreamTrack
  * Controller of creating new [PeerConnectionController]s by a [PeerConnectionFactoryProxy].
  *
  * @property messenger Messenger used for creating new [MethodChannel]s.
- * @param state State used for creating new [PeerConnectionFactoryProxy]s.
+ * @property state State used for creating new [PeerConnectionFactoryProxy]s.
+ * @param mediaDevices [MediaDevices] used for creating new [PeerConnectionFactoryProxy]s.
  */
 class PeerConnectionFactoryController(
     private val messenger: BinaryMessenger,

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/RtpSenderController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/RtpSenderController.kt
@@ -91,7 +91,7 @@ class RtpSenderController(messenger: BinaryMessenger, private val sender: RtpSen
   }
 
   override fun dispose() {
-    // Not disposing the actual RtpSenderProxy because its lifetime is bound
+    // Not disposing the actual RtpSenderProxyб because its lifetime is bound
     // to the transceiver.
     ControllerRegistry.unregister(this)
     chan.setMethodCallHandler(null)

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/RtpSenderController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/RtpSenderController.kt
@@ -86,13 +86,15 @@ class RtpSenderController(messenger: BinaryMessenger, private val sender: RtpSen
         dispose()
         result.success(null)
       }
+      else -> result.notImplemented()
     }
   }
 
   override fun dispose() {
+    // Not disposing the actual RtpSenderProxy because its lifetime is bound
+    // to the transceiver.
     ControllerRegistry.unregister(this)
     chan.setMethodCallHandler(null)
-    sender.setDisposed()
   }
 
   /**

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/RtpTransceiverController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/RtpTransceiverController.kt
@@ -77,6 +77,7 @@ class RtpTransceiverController(
         disposeInternal(false)
         result.success(null)
       }
+      else -> result.notImplemented()
     }
   }
 

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/VideoRendererController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/VideoRendererController.kt
@@ -75,6 +75,7 @@ class VideoRendererController(
         dispose()
         result.success(null)
       }
+      else -> result.notImplemented()
     }
   }
 

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/VideoRendererFactoryController.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/controller/VideoRendererFactoryController.kt
@@ -30,6 +30,7 @@ class VideoRendererFactoryController(
         val renderer = FlutterRtcVideoRenderer(textureRegistry)
         result.success(VideoRendererController(messenger, renderer).asFlutterResult())
       }
+      else -> result.notImplemented()
     }
   }
 

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/media/AudioFocusCompat.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/media/AudioFocusCompat.kt
@@ -1,0 +1,229 @@
+package com.instrumentisto.medea_flutter_webrtc.media
+
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import com.instrumentisto.medea_flutter_webrtc.State
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+
+private val TAG = AudioFocusCompat::class.java.simpleName
+
+/** Timeout for awaiting delayed audio focus gain, in milliseconds. */
+private const val FOCUS_REQUEST_TIMEOUT_MS: Long = 10_000
+
+/** Compatibility facade for Android audio focus handling. */
+abstract class AudioFocusCompat private constructor(state: State) {
+  /** [AudioManager] system service used to make focus requests. */
+  protected val audioManager: AudioManager = state.getAudioManager()
+
+  @Volatile
+  /** Whether audio focus is currently granted to this app. */
+  protected var granted: Boolean = false
+
+  /** Shared deferred for the current in-flight focus grant, if any. */
+  @Volatile protected var pendingGrant: CompletableDeferred<Boolean>? = null
+
+  /** Mutex to serialize request creation/dispatch. */
+  private val requestMutex = Mutex()
+
+  /**
+   * Listener that updates [granted] when the system reports focus changes.
+   *
+   * The field is shared by both implementations to centralize state updates.
+   */
+  protected val onAudioFocusChangeListener: AudioManager.OnAudioFocusChangeListener =
+      AudioManager.OnAudioFocusChangeListener { focusChange: Int ->
+        if (focusChange == AudioManager.AUDIOFOCUS_GAIN) {
+          granted = true
+          pendingGrant?.let { d -> if (!d.isCompleted) d.complete(true) }
+          pendingGrant = null
+        } else {
+          granted = false
+          pendingGrant?.let { d -> if (!d.isCompleted) d.complete(false) }
+          pendingGrant = null
+        }
+      }
+
+  companion object {
+    /**
+     * Creates a platform-appropriate [AudioFocusCompat] instance for the current device SDK level.
+     */
+    @JvmStatic
+    fun create(state: State): AudioFocusCompat {
+      return if (Build.VERSION.SDK_INT >= 26) {
+        AudioFocusSdk26(state)
+      } else {
+        AudioFocusSdk8(state)
+      }
+    }
+  }
+
+  /**
+   * Requests audio focus for voice communication.
+   *
+   * Suspends until focus is actually granted (either synchronously or via a delayed gain callback).
+   * Returns false only if the system immediately rejects the request.
+   */
+  suspend fun requestAudioFocus(): Boolean {
+    if (granted) {
+      return true
+    }
+
+    pendingGrant?.let { existing ->
+      return awaitPendingGrant(existing)
+    }
+
+    return requestMutex.withLock {
+      if (granted) {
+        return true
+      }
+
+      val result =
+          try {
+            requestAudioFocusInner()
+          } catch (e: SecurityException) {
+            Log.w(TAG, "Audio focus not granted. Result code: $e")
+            return false
+          }
+
+      when (result) {
+        AudioManager.AUDIOFOCUS_REQUEST_GRANTED -> {
+          granted = true
+          true
+        }
+        AudioManager.AUDIOFOCUS_REQUEST_DELAYED -> {
+          val pending = CompletableDeferred<Boolean>()
+          pendingGrant = pending
+          return awaitPendingGrant(pending)
+        }
+        else -> {
+          Log.w(TAG, "Audio focus not granted. Result code: $result")
+          false
+        }
+      }
+    }
+  }
+
+  /**
+   * Performs the platform-specific focus request and returns the raw result code from
+   * AudioManager.requestAudioFocus.
+   */
+  protected abstract fun requestAudioFocusInner(): Int
+
+  /** Abandons audio focus previously acquired via [requestAudioFocus]. */
+  abstract fun abandonAudioFocus()
+
+  /** Awaits the provided [CompletableDeferred] with a timeout, cleaning up state on timeout. */
+  private suspend fun awaitPendingGrant(pending: CompletableDeferred<Boolean>): Boolean {
+    val result = withTimeoutOrNull(FOCUS_REQUEST_TIMEOUT_MS) { pending.await() }
+    if (result == null) {
+      Log.w(TAG, "Audio focus request timed out after ${FOCUS_REQUEST_TIMEOUT_MS} ms")
+      if (!pending.isCompleted) {
+        pending.complete(false)
+      }
+      pendingGrant = null
+      return false
+    }
+    return result
+  }
+
+  /** API 26+ implementation backed by [AudioFocusRequest]. */
+  @RequiresApi(26)
+  private class AudioFocusSdk26(state: State) : AudioFocusCompat(state) {
+    /** Lazily constructed focus requests (immediate vs delayed). */
+    private var immediateRequest: AudioFocusRequest? = null
+    private var delayedRequest: AudioFocusRequest? = null
+    private var activeAudioFocusRequest: AudioFocusRequest? = null
+
+    companion object {
+      /** Audio attributes appropriate for voice communication use cases. */
+      private val AUDIO_ATTRIBUTES: AudioAttributes =
+          AudioAttributes.Builder()
+              .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+              .setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION)
+              .build()
+    }
+
+    override fun requestAudioFocusInner(): Int {
+      // Try to request focus without delay first. If it fails then
+      // retry with setAcceptsDelayedFocusGain(true).
+      if (immediateRequest == null) {
+        immediateRequest =
+            AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+                .setAudioAttributes(AUDIO_ATTRIBUTES)
+                .setOnAudioFocusChangeListener(onAudioFocusChangeListener)
+                .setAcceptsDelayedFocusGain(false)
+                .build()
+      }
+
+      var result = audioManager.requestAudioFocus(immediateRequest!!)
+      if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+        activeAudioFocusRequest = immediateRequest
+        return result
+      }
+
+      if (delayedRequest == null) {
+        delayedRequest =
+            AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+                .setAudioAttributes(AUDIO_ATTRIBUTES)
+                .setOnAudioFocusChangeListener(onAudioFocusChangeListener)
+                .setAcceptsDelayedFocusGain(true)
+                .build()
+      }
+
+      result = audioManager.requestAudioFocus(delayedRequest!!)
+      if (result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED ||
+          result == AudioManager.AUDIOFOCUS_REQUEST_DELAYED) {
+        activeAudioFocusRequest = delayedRequest
+      }
+
+      return result
+    }
+
+    /** Abandons the previously requested audio focus, if any. */
+    override fun abandonAudioFocus() {
+      if (activeAudioFocusRequest == null) {
+        return
+      }
+
+      val result = audioManager.abandonAudioFocusRequest(activeAudioFocusRequest!!)
+
+      if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+        Log.w(TAG, "Audio focus abandon failed. Result code: $result")
+      }
+
+      granted = false
+      pendingGrant?.let { d -> if (!d.isCompleted) d.complete(false) }
+      pendingGrant = null
+      activeAudioFocusRequest = null
+    }
+  }
+
+  /** Pre-API 26 implementation backed by legacy [AudioManager] APIs. */
+  private class AudioFocusSdk8(state: State) : AudioFocusCompat(state) {
+    override fun requestAudioFocusInner(): Int {
+      return audioManager.requestAudioFocus(
+          onAudioFocusChangeListener,
+          AudioManager.STREAM_VOICE_CALL,
+          AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+    }
+
+    override fun abandonAudioFocus() {
+      val result = audioManager.abandonAudioFocus(onAudioFocusChangeListener)
+
+      if (result != AudioManager.AUDIOFOCUS_REQUEST_GRANTED) {
+        Log.w(TAG, "Audio focus abandon failed. Result code: $result")
+      }
+
+      granted = false
+      pendingGrant?.let { d -> if (!d.isCompleted) d.complete(false) }
+      pendingGrant = null
+    }
+  }
+}

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/media/MediaDevices.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/media/MediaDevices.kt
@@ -81,7 +81,7 @@ class MediaDevices(val state: State, val permissions: Permissions) : BroadcastRe
   /** Indicator of bluetooth headset connection state. */
   private var isBluetoothHeadsetConnected: Boolean = false
 
-  /** Indicator of a wired headset connection state. */
+  /** Indicator of wired headset connection state. */
   private var isWiredHeadsetConnected: Boolean = false
 
   /**
@@ -149,7 +149,7 @@ class MediaDevices(val state: State, val permissions: Permissions) : BroadcastRe
   }
 
   /**
-   * Prepares the app for an ongoing VoIP session.
+   * Prepares for an ongoing VoIP session.
    *
    * - Sets [AudioManager.mode] to [AudioManager.MODE_IN_COMMUNICATION].
    * - Requests audio focus.
@@ -271,7 +271,7 @@ class MediaDevices(val state: State, val permissions: Permissions) : BroadcastRe
    */
   private suspend fun stopBluetoothSco() {
     if (Build.VERSION.SDK_INT >= 31) {
-      // Prefer modern routing API on Android 12+
+      // Prefer modern routing API on Android 12+.
       audioManager.clearCommunicationDevice()
       stopBluetoothScoDeferred?.complete(Unit)
       stopBluetoothScoDeferred = null
@@ -306,7 +306,8 @@ class MediaDevices(val state: State, val permissions: Permissions) : BroadcastRe
             stopBluetoothSco()
           }
           if (Build.VERSION.SDK_INT >= 31) {
-            // Clear explicit routing; system will select the appropriate earpiece/wired device
+            // Clear explicit routing.
+            // System will select the appropriate earpiece/wired device.
             audioManager.clearCommunicationDevice()
           } else {
             audioManager.isSpeakerphoneOn = false

--- a/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/proxy/PeerConnectionFactoryProxy.kt
+++ b/android/src/main/kotlin/com/instrumentisto/medea_flutter_webrtc/proxy/PeerConnectionFactoryProxy.kt
@@ -1,9 +1,8 @@
 package com.instrumentisto.medea_flutter_webrtc.proxy
 
-import android.media.AudioManager.*
-import com.instrumentisto.medea_flutter_webrtc.ForegroundCallService
 import com.instrumentisto.medea_flutter_webrtc.Permissions
 import com.instrumentisto.medea_flutter_webrtc.State
+import com.instrumentisto.medea_flutter_webrtc.media.MediaDevices
 import com.instrumentisto.medea_flutter_webrtc.model.PeerConnectionConfiguration
 import org.webrtc.PeerConnectionFactory
 
@@ -12,7 +11,11 @@ import org.webrtc.PeerConnectionFactory
  *
  * @property state Global state used for creation.
  */
-class PeerConnectionFactoryProxy(private val state: State, private val permissions: Permissions) {
+class PeerConnectionFactoryProxy(
+    private val state: State,
+    private val mediaDevices: MediaDevices,
+    private val permissions: Permissions
+) {
   /** Counter for generating new [PeerConnectionProxy] IDs. */
   private var lastPeerConnectionId: Int = 0
 
@@ -44,8 +47,7 @@ class PeerConnectionFactoryProxy(private val state: State, private val permissio
     peerProxy.onDispose(::removePeerObserver)
 
     if (peerObservers.isEmpty()) {
-      state.getAudioManager().mode = MODE_IN_COMMUNICATION
-      ForegroundCallService.start(state.context, permissions)
+      mediaDevices.startVoIP()
     }
 
     peerObservers[id] = peerObserver
@@ -70,8 +72,7 @@ class PeerConnectionFactoryProxy(private val state: State, private val permissio
   private fun removePeerObserver(id: Int) {
     peerObservers.remove(id)
     if (peerObservers.isEmpty()) {
-      state.getAudioManager().mode = MODE_NORMAL
-      ForegroundCallService.stop(state.context, permissions)
+      mediaDevices.stopVoIP()
     }
   }
 

--- a/example/lib/src/loopback.dart
+++ b/example/lib/src/loopback.dart
@@ -60,6 +60,16 @@ class _LoopbackState extends State<Loopback> {
         });
       }
     }();
+
+    onDeviceChange(() async {
+      try {
+        final devices = await enumerateDevices();
+        if (!mounted) return;
+        setState(() {
+          _mediaDevicesList = devices;
+        });
+      } catch (_) {}
+    });
   }
 
   @override
@@ -70,6 +80,7 @@ class _LoopbackState extends State<Loopback> {
     }
     _localRenderer.dispose();
     _remoteRenderer.dispose();
+    onDeviceChange(null);
   }
 
   void initRenderers() async {

--- a/example/lib/src/on_device_change.dart
+++ b/example/lib/src/on_device_change.dart
@@ -17,13 +17,15 @@ class _State extends State<OnDeviceChangeNotifierSample> {
   void initState() {
     super.initState();
 
+    _handleOnDeviceChange();
+
     onDeviceChange(() {
+      count++;
       _handleOnDeviceChange();
     });
   }
 
   void _handleOnDeviceChange() async {
-    count++;
     var mediaDeviceInfos = await enumerateDevices();
     var mediaDisplayInfos = await enumerateDisplays();
 


### PR DESCRIPTION
## Synopsis

Few things here:
1. `isSpeakerphoneOn`, `startBluetoothSco`, `stopBluetoothSco` are deprecated
2. no `onDeviceChange` when wired headset is connected/disconnected
3. capturing audio focus would be nice



## Solution

1. Use new AudioManager APIs when available. (TODO: properly support multiple bluetooth headsets?)
2. Add `wired-headset` device. Fire `onDeviceChanged` when it's connected/disconnected (it will replace `ear-speaker` if connected)
3. Capture audio focus when there are at least one peer connection exists, abandon when there are none



## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
